### PR TITLE
Assembly Extensions

### DIFF
--- a/src/Ayaka/Reflection/AssemblyExtensions.cs
+++ b/src/Ayaka/Reflection/AssemblyExtensions.cs
@@ -1,0 +1,246 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Ayaka.Reflection
+{
+    /// <summary>
+    ///     Provides additional functionality for <see cref="Assembly" />.
+    /// </summary>
+    public static class AssemblyExtensions
+    {
+        /// <summary>
+        ///     Gets the <see typeref="TAttribute" /> from the specified <see cref="Assembly" />.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="throwIfNotFound">If set to <c>true</c> throws an exception if the attribute is not found.</param>
+        /// <returns>A <see typeref="TAttribute" /> instance.</returns>
+        public static TAttribute GetAttribute<TAttribute>(this Assembly assembly, bool throwIfNotFound = false)
+            where TAttribute : Attribute
+        {
+            if (assembly == null)
+            {
+                return null;
+            }
+
+            var attributes = assembly.GetCustomAttributes(typeof(TAttribute), false)
+                .Cast<TAttribute>()
+                .ToArray();
+
+            if (!attributes.Any())
+            {
+                if (throwIfNotFound)
+                {
+                    throw new InvalidOperationException(
+                        $"Could not find '{typeof(TAttribute)}' of '{assembly.FullName}'");
+                }
+
+                return null;
+            }
+
+            return attributes.First();
+        }
+
+        /// <summary>
+        ///     Gets the <see cref="AssemblyVersionAttribute" /> from the specified <see cref="Assembly" />.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="throwIfNotFound">If set to <c>true</c> throws an exception if the attribute is not found.</param>
+        /// <returns>A <see cref="Version" /> representing the attribute's value.</returns>
+        public static Version GetVersion(this Assembly assembly, bool throwIfNotFound = false)
+        {
+            return assembly.GetName().Version;
+        }
+
+        /// <summary>
+        ///     Gets the <see cref="AssemblyFileVersionAttribute" /> from the specified <see cref="Assembly" />.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="throwIfNotFound">If set to <c>true</c> throws an exception if the attribute is not found.</param>
+        /// <returns>A <see cref="Version" /> representing the attribute's value.</returns>
+        public static Version GetFileVersion(this Assembly assembly, bool throwIfNotFound = false)
+        {
+            var fileVersionAttribute = assembly.GetAttribute<AssemblyFileVersionAttribute>(throwIfNotFound);
+            if (fileVersionAttribute == null)
+            {
+                return new Version(0, 0, 0, 0);
+            }
+
+            return Version.Parse(fileVersionAttribute.Version);
+        }
+
+        /// <summary>
+        ///     Gets the <see cref="AssemblyTitleAttribute" /> from the specified <see cref="Assembly" />.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="throwIfNotFound">If set to <c>true</c> throws an exception if the attribute is not found.</param>
+        /// <returns>A string representing the attribute's value.</returns>
+        public static string GetTitle(this Assembly assembly, bool throwIfNotFound = false)
+        {
+            var titleAttribute = assembly.GetAttribute<AssemblyTitleAttribute>(throwIfNotFound);
+            if (titleAttribute == null)
+            {
+                return null;
+            }
+
+            return titleAttribute.Title;
+        }
+
+        /// <summary>
+        ///     Gets the <see cref="AssemblyDescriptionAttribute" /> from the specified <see cref="Assembly" />.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="throwIfNotFound">If set to <c>true</c> throws an exception if the attribute is not found.</param>
+        /// <returns>A string representing the attribute's value.</returns>
+        public static string GetDescription(this Assembly assembly, bool throwIfNotFound = false)
+        {
+            var descriptionAttribute = assembly.GetAttribute<AssemblyDescriptionAttribute>(throwIfNotFound);
+            if (descriptionAttribute == null)
+            {
+                return null;
+            }
+
+            return descriptionAttribute.Description;
+        }
+
+        /// <summary>
+        ///     Gets the <see cref="AssemblyProductAttribute" /> from the specified <see cref="Assembly" />.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="throwIfNotFound">If set to <c>true</c> throws an exception if the attribute is not found.</param>
+        /// <returns>A string representing the attribute's value.</returns>
+        public static string GetProduct(this Assembly assembly, bool throwIfNotFound = false)
+        {
+            var productAttribute = assembly.GetAttribute<AssemblyProductAttribute>(throwIfNotFound);
+            if (productAttribute == null)
+            {
+                return null;
+            }
+
+            return productAttribute.Product;
+        }
+
+        /// <summary>
+        ///     Gets the <see cref="AssemblyCompanyAttribute" /> from the specified <see cref="Assembly" />.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="throwIfNotFound">If set to <c>true</c> throws an exception if the attribute is not found.</param>
+        /// <returns>A string representing the attribute's value.</returns>
+        public static string GetCompany(this Assembly assembly, bool throwIfNotFound = false)
+        {
+            var companyAttribute = assembly.GetAttribute<AssemblyCompanyAttribute>(throwIfNotFound);
+            if (companyAttribute == null)
+            {
+                return null;
+            }
+
+            return companyAttribute.Company;
+        }
+
+        /// <summary>
+        ///     Gets the <see cref="AssemblyCopyrightAttribute" /> from the specified <see cref="Assembly" />.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="throwIfNotFound">If set to <c>true</c> throws an exception if the attribute is not found.</param>
+        /// <returns>A string representing the attribute's value.</returns>
+        public static string GetCopyright(this Assembly assembly, bool throwIfNotFound = false)
+        {
+            var copyrightAttribute = assembly.GetAttribute<AssemblyCopyrightAttribute>(throwIfNotFound);
+            if (copyrightAttribute == null)
+            {
+                return null;
+            }
+
+            return copyrightAttribute.Copyright;
+        }
+
+        /// <summary>
+        ///     Gets the <see cref="AssemblyTrademarkAttribute" /> from the specified <see cref="Assembly" />.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="throwIfNotFound">If set to <c>true</c> throws an exception if the attribute is not found.</param>
+        /// <returns>A string representing the attribute's value.</returns>
+        public static string GetTrademark(this Assembly assembly, bool throwIfNotFound = false)
+        {
+            var trademarkAttribute = assembly.GetAttribute<AssemblyTrademarkAttribute>(throwIfNotFound);
+            if (trademarkAttribute == null)
+            {
+                return null;
+            }
+
+            return trademarkAttribute.Trademark;
+        }
+
+        /// <summary>
+        ///     Gets the <see cref="AssemblyCultureAttribute" /> from the specified <see cref="Assembly" />.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="throwIfNotFound">If set to <c>true</c> throws an exception if the attribute is not found.</param>
+        /// <returns>A string representing the attribute's value.</returns>
+        public static string GetCulture(this Assembly assembly, bool throwIfNotFound = false)
+        {
+            var cultureAttribute = assembly.GetAttribute<AssemblyCultureAttribute>(throwIfNotFound);
+            if (cultureAttribute == null)
+            {
+                return null;
+            }
+
+            return cultureAttribute.Culture;
+        }
+
+        /// <summary>
+        ///     Gets the <see cref="AssemblyConfigurationAttribute" /> from the specified <see cref="Assembly" />.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="throwIfNotFound">If set to <c>true</c> throws an exception if the attribute is not found.</param>
+        /// <returns>A string representing the attribute's value.</returns>
+        public static string GetConfiguration(this Assembly assembly, bool throwIfNotFound = false)
+        {
+            var configurationAttribute = assembly.GetAttribute<AssemblyConfigurationAttribute>(throwIfNotFound);
+            if (configurationAttribute == null)
+            {
+                return null;
+            }
+
+            return configurationAttribute.Configuration;
+        }
+
+        /// <summary>
+        ///     Gets the <see cref="GuidAttribute" /> from the specified <see cref="Assembly" />.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="throwIfNotFound">If set to <c>true</c> throws an exception if the attribute is not found.</param>
+        /// <returns>A <see cref="Guid" /> representing the attribute's value.</returns>
+        public static Guid GetGuid(this Assembly assembly, bool throwIfNotFound = false)
+        {
+            var guidAttribute = assembly.GetAttribute<GuidAttribute>(throwIfNotFound);
+            if (guidAttribute == null)
+            {
+                return Guid.Empty;
+            }
+
+            return Guid.Parse(guidAttribute.Value);
+        }
+
+        /// <summary>
+        ///     Determines whether the specified <see cref="Assembly" /> is debuggable.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="throwIfNotFound">If set to <c>true</c> throws an exception if the attribute is not found.</param>
+        /// <returns>
+        ///     <c>true</c> if the specified is debuggable; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsDebuggable(this Assembly assembly, bool throwIfNotFound = false)
+        {
+            var debuggableAttribute = assembly.GetAttribute<DebuggableAttribute>(throwIfNotFound);
+            if (debuggableAttribute == null)
+            {
+                return false;
+            }
+
+            return (debuggableAttribute.DebuggingFlags & DebuggableAttribute.DebuggingModes.Default) == DebuggableAttribute.DebuggingModes.Default;
+        }
+    }
+}

--- a/test/Ayaka.Tests/Reflection/AssemblyExtensionsTest.cs
+++ b/test/Ayaka.Tests/Reflection/AssemblyExtensionsTest.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) Raphael Strotz and other contributors under the MIT license. All rights reserved.
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Moq;
+using Xunit;
+
+namespace Ayaka.Reflection
+{
+    public class AssemblyExtensionsTest
+    {
+        [Fact]
+        public void Can_get_file_version()
+        {
+            var fileVersion = PrepareMock(fileVersion: "10.0.7.1")
+                .GetFileVersion(true);
+
+            Assert.NotNull(fileVersion);
+            Assert.Equal(new Version("10.0.7.1"), fileVersion);
+        }
+
+        [Fact]
+        public void Can_get_version()
+        {
+            var version = PrepareMock(version: "10.0.0.7")
+                .GetVersion(true);
+
+            Assert.NotNull(version);
+            Assert.Equal(new Version("10.0.0.7"), version);
+        }
+
+        [Fact]
+        public void Can_get_title()
+        {
+            var title = PrepareMock(title: "FakeAssembly")
+                .GetTitle(true);
+
+            Assert.NotNull(title);
+            Assert.Equal("FakeAssembly", title);
+        }
+
+        [Fact]
+        public void Can_get_description()
+        {
+            var description = PrepareMock(desciption: "Fake Assembly")
+                .GetDescription(true);
+
+            Assert.NotNull(description);
+            Assert.Equal("Fake Assembly", description);
+        }
+
+        [Fact]
+        public void Can_get_product()
+        {
+            var product = PrepareMock(product: "FakeAssembly")
+                .GetProduct(true);
+
+            Assert.NotNull(product);
+            Assert.Equal("FakeAssembly", product);
+        }
+
+        [Fact]
+        public void Can_get_company()
+        {
+            var company = PrepareMock(company: "Contoso")
+                .GetCompany(true);
+
+            Assert.NotNull(company);
+            Assert.Equal("Contoso", company);
+        }
+
+        [Fact]
+        public void Can_get_copyright()
+        {
+            var copyright = PrepareMock(copyright: "Copyright © Contoso 2017")
+                .GetCopyright(true);
+
+            Assert.NotNull(copyright);
+            Assert.Equal("Copyright © Contoso 2017", copyright);
+        }
+
+        [Fact]
+        public void Can_get_trademark()
+        {
+            var trademark = PrepareMock(trademark: "FakeAssembly")
+                .GetTrademark(true);
+
+            Assert.NotNull(trademark);
+            Assert.Equal("FakeAssembly", trademark);
+        }
+
+        [Fact]
+        public void Can_get_culture()
+        {
+            var culture = PrepareMock(culture: "en-US")
+                .GetCulture(true);
+
+            Assert.NotNull(culture);
+            Assert.Equal("en-US", culture);
+        }
+
+        [Fact]
+        public void Can_get_configuration()
+        {
+            var configuration = PrepareMock(configuration: "DEBUG")
+                .GetConfiguration(true);
+
+            Assert.NotNull(configuration);
+            Assert.Equal("DEBUG", configuration);
+        }
+
+
+        [Fact]
+        public void Can_get_guid()
+        {
+            var expected = Guid.NewGuid();
+            var actual = PrepareMock(guid: expected.ToString())
+                .GetGuid(true);
+
+            Assert.Equal(expected, actual);
+        }
+
+
+        [Fact]
+        public void Can_get_debuggable_flag()
+        {
+            var debuggable = PrepareMock(debuggable: true)
+                .IsDebuggable(true);
+
+            Assert.True(debuggable);
+        }
+
+        [Fact]
+        public void Throws_when_missing_attribute()
+        {
+            Assert.Throws<InvalidOperationException>(() => PrepareMock()
+                .GetCopyright(true));
+        }
+
+        private Assembly PrepareMock(
+            string name = "FakeAssembly",
+            string version = "1.0.0.0",
+            string fileVersion = null,
+            string title = null,
+            string desciption = null,
+            string product = null,
+            string company = null,
+            string copyright = null,
+            string trademark = null,
+            string culture = null,
+            string configuration = null,
+            string guid = null,
+            bool? debuggable = null)
+        {
+            var mock = new Mock<Assembly>();
+
+            mock.Setup(a => a.GetName())
+                .Returns(new AssemblyName($"{name}, Version=\"{version}\""));
+
+            Setup<AssemblyVersionAttribute>(version);
+            Setup<AssemblyFileVersionAttribute>(fileVersion);
+            Setup<AssemblyTitleAttribute>(title);
+            Setup<AssemblyDescriptionAttribute>(desciption);
+            Setup<AssemblyProductAttribute>(product);
+            Setup<AssemblyCompanyAttribute>(company);
+            Setup<AssemblyCopyrightAttribute>(copyright);
+            Setup<AssemblyTrademarkAttribute>(trademark);
+            Setup<AssemblyCultureAttribute>(culture);
+            Setup<AssemblyConfigurationAttribute>(configuration);
+            Setup<GuidAttribute>(guid);
+            Setup<DebuggableAttribute>(debuggable.HasValue && debuggable.Value
+                ? DebuggableAttribute.DebuggingModes.Default
+                : DebuggableAttribute.DebuggingModes.DisableOptimizations);
+
+            void Setup<TAttribute>(object argument)
+            {
+                if (argument != null)
+                {
+                    mock.Setup(a => a.GetCustomAttributes(typeof(TAttribute), false))
+                        .Returns(new[] {Activator.CreateInstance(typeof(TAttribute), argument)});
+                }
+            }
+
+            return mock.Object;
+        }
+    }
+}


### PR DESCRIPTION
# Description

Added extensions for getting assembly informations.

Resolves #4 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How has this been tested?

New feature has been tested using unit tests.
- AssemblyExtensionsTest
  - Can_get_file_version
  - Can_get_version
  - Can_get_title
  - Can_get_description
  - Can_get_product
  - Can_get_company
  - Can_get_copyright
  - Can_get_trademark
  - Can_get_culture
  - Can_get_configuration
  - Can_get_guid
  - Can_get_debuggable_flag
  - Throws_when_missing_attribute

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules