### PR TITLE
Expiration token for cache entries

### DIFF
--- a/src/Ayaka/Caching/CacheManagerExtensions.cs
+++ b/src/Ayaka/Caching/CacheManagerExtensions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Primitives;
 
 namespace Ayaka.Caching
 {
@@ -34,15 +35,16 @@ namespace Ayaka.Caching
         /// <param name="key">The key of the value to get.</param>
         /// <param name="acquire">The function to acquire the cache value, if it does not exist.</param>
         /// <param name="expiresIn">Optional expiration of the value.</param>
+        /// <param name="expirationToken">Optional <see cref="IChangeToken"/> that causes the cache entry to expire.</param>
         /// <returns>The value associated with the specified key.</returns>
-        public static TValue Get<TValue>(this ICacheManager cacheManager, string key, Func<TValue> acquire, TimeSpan? expiresIn = null)
+        public static TValue Get<TValue>(this ICacheManager cacheManager, string key, Func<TValue> acquire, TimeSpan? expiresIn = null, IChangeToken expirationToken = null)
         {
             if (cacheManager == null) throw new ArgumentNullException(nameof(cacheManager));
 
             if (cacheManager.Exists(key)) return (TValue) cacheManager.Get(key);
 
             var value = acquire();
-            cacheManager.Set(key, value, expiresIn);
+            cacheManager.Set(key, value, expiresIn, expirationToken);
 
             return value;
         }
@@ -55,18 +57,19 @@ namespace Ayaka.Caching
         /// <param name="key">The key of the value to get.</param>
         /// <param name="acquire">The function to acquire the cache value, if it does not exist.</param>
         /// <param name="expiresIn">Optional expiration of the value.</param>
+        /// <param name="expirationToken">Optional <see cref="IChangeToken"/> that causes the cache entry to expire.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the value associated with the
         ///     specified key.
         /// </returns>
-        public static async Task<TValue> GetAsync<TValue>(this ICacheManager cacheManager, string key, Func<Task<TValue>> acquire, TimeSpan? expiresIn = null)
+        public static async Task<TValue> GetAsync<TValue>(this ICacheManager cacheManager, string key, Func<Task<TValue>> acquire, TimeSpan? expiresIn = null, IChangeToken expirationToken = null)
         {
             if (cacheManager == null) throw new ArgumentNullException(nameof(cacheManager));
 
             if (cacheManager.Exists(key)) return (TValue) cacheManager.Get(key);
 
             var value = await acquire();
-            cacheManager.Set(key, value, expiresIn);
+            cacheManager.Set(key, value, expiresIn, expirationToken);
 
             return value;
         }
@@ -79,11 +82,12 @@ namespace Ayaka.Caching
         /// <param name="key">The key of the value.</param>
         /// <param name="value">The value to store.</param>
         /// <param name="expiresIn">Optional expiration of the value.</param>
-        public static void Set<TValue>(this ICacheManager cacheManager, string key, TValue value, TimeSpan? expiresIn = null)
+        /// <param name="expirationToken">Optional <see cref="IChangeToken"/> that causes the cache entry to expire.</param>
+        public static void Set<TValue>(this ICacheManager cacheManager, string key, TValue value, TimeSpan? expiresIn = null, IChangeToken expirationToken = null)
         {
             if (cacheManager == null) throw new ArgumentNullException(nameof(cacheManager));
 
-            cacheManager.Set(key, value, expiresIn);
+            cacheManager.Set(key, value, expiresIn, expirationToken);
         }
 
         /// <summary>

--- a/src/Ayaka/Caching/ICacheManager.cs
+++ b/src/Ayaka/Caching/ICacheManager.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Primitives;
 
 namespace Ayaka.Caching
 {
@@ -37,8 +38,9 @@ namespace Ayaka.Caching
         /// </summary>
         /// <param name="key">The key of the value.</param>
         /// <param name="value">The value to store.</param>
-        /// <param name="expiresIn">Optional expiration of the value.</param>
-        void Set(string key, object value, TimeSpan? expiresIn = null);
+        /// <param name="expiresIn">Optional expiration of the value.</param> 
+        /// <param name="expirationToken">Optional <see cref="IChangeToken"/> that causes the cache entry to expire.</param>
+        void Set(string key, object value, TimeSpan? expiresIn = null, IChangeToken expirationToken = null);
 
         /// <summary>
         ///     Removes the value with the specified key from the cache.

--- a/src/Ayaka/Caching/Memory/MemoryCacheManager.cs
+++ b/src/Ayaka/Caching/Memory/MemoryCacheManager.cs
@@ -67,12 +67,19 @@ namespace Ayaka.Caching.Memory
         /// </summary>
         /// <param name="key">The key of the value.</param>
         /// <param name="value">The value to store.</param>
-        /// <param name="expiresIn">Optional expiration of the value.</param>
-        public void Set(string key, object value, TimeSpan? expiresIn = null)
+        /// <param name="expiresIn">Optional expiration of the value.</param> 
+        /// <param name="expirationToken">Optional <see cref="IChangeToken"/> that causes the cache entry to expire.</param>
+        public void Set(string key, object value, TimeSpan? expiresIn = null, IChangeToken expirationToken = null)
         {
             var options = new MemoryCacheEntryOptions();
             options.SetAbsoluteExpiration(expiresIn ?? _options.DefaultExpiration);
             options.AddExpirationToken(new CancellationChangeToken(_tokenSource.Token));
+
+            if (expirationToken != null)
+            {
+                options.AddExpirationToken(expirationToken);
+            }
+
             options.RegisterPostEvictionCallback((k, v, r, s) =>
             {
                 if (r == EvictionReason.Replaced) return;


### PR DESCRIPTION
# Description

Added an optional `IChangeToken` argument to `ICacheManager.Set(...)`.
This change allows expiring cache entries from another source than absolute expiration.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
Expecting `MemoryCache` to be tested from dotnet team.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules