### PR TITLE
feat: add support for dotnet-validate CLI tool

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -8,20 +8,6 @@
         "nuke"
       ],
       "rollForward": false
-    },
-    "gitversion.tool": {
-      "version": "5.12.0",
-      "commands": [
-        "dotnet-gitversion"
-      ],
-      "rollForward": false
-    },
-    "dotnet-validate": {
-      "version": "0.0.1-preview.304",
-      "commands": [
-        "dotnet-validate"
-      ],
-      "rollForward": false
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4
-        id: setup-dotnet
 
       - name: Restore .NET Tools
         run: |
@@ -60,59 +59,9 @@ jobs:
           path: ${{ github.workspace }}/artifacts/packages
           if-no-files-found: error
 
-      - name: Output .NET Tool Versions
-        id: tool-versions
-        run: |
-          dotnet_validate_version=$(jq -r '.tools["dotnet-validate"].version' ./.config/dotnet-tools.json)
-          echo "dotnet-validate-version=$dotnet_validate_version" >> $GITHUB_OUTPUT
-
-    outputs:
-      dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
-      dotnet-validate-version: ${{ steps.tool-versions.outputs.dotnet-validate-version }}
-
-  validate-packages:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - name: Download Packages
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4
-        with:
-          name: packages
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4
-        with:
-          dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
-
-      - name: Install .NET Tools
-        run: |
-          dotnet tool install \
-            --global \
-            --version $DOTNET_VALIDATE_VERSION \
-            dotnet-validate
-        env:
-          DOTNET_VALIDATE_VERSION: ${{ needs.build.outputs.dotnet-validate-version }}
-
-      - name: Validate Packages
-        run: |
-          fail_count=0
-
-          for file in "${{ github.workspace }}/*.nupkg"; do
-            dotnet validate package local $file
-            if [ $? -ne 0 ]; then
-              ((fail_count++))
-            fi
-          done
-
-          if [ $fail_count -ne 0 ]; then
-            echo "::error::Validation failed for $fail_count NuGet package(s)"
-            exit 1
-          fi
-
   publish-packages:
     runs-on: ubuntu-latest
-    needs: [build, validate-packages]
+    needs: [build]
 
     # Only publish if build was triggered for a tag
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -93,6 +93,7 @@
               "DotNetPush",
               "DotNetRestore",
               "DotNetTest",
+              "DotNetValidate",
               "Pack",
               "Publish",
               "Test"
@@ -117,6 +118,7 @@
               "DotNetPush",
               "DotNetRestore",
               "DotNetTest",
+              "DotNetValidate",
               "Pack",
               "Publish",
               "Test"

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -2,6 +2,7 @@
 
 using Ayaka.Nuke;
 using Ayaka.Nuke.DotNet;
+using Ayaka.Nuke.DotNetValidate;
 using Ayaka.Nuke.NuGet;
 using Nuke.Common;
 using Nuke.Common.Tools.DotNet;
@@ -25,6 +26,7 @@ class Build
         ICanDotNetBuild,
         ICanDotNetTest,
         ICanDotNetPack,
+        ICanDotNetValidate,
         ICanDotNetPush
 {
     public static int Main() => Execute<Build>(x => x.Default);
@@ -48,7 +50,8 @@ class Build
     Target Pack => target => target
         .Description("Packs all NuGet packages in the Solution")
         .DependsOn<IHaveCleanTarget>()
-        .DependsOn<IHaveDotNetPackTarget>();
+        .DependsOn<IHaveDotNetPackTarget>()
+        .DependsOn<IHaveDotNetValidateTarget>();
 
     Target Publish => target => target
         .Description("Publishes all NuGet packages in the Solution")

--- a/nukebuild/Build.csproj
+++ b/nukebuild/Build.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageDownload Include="dotnet-validate" Version="[0.0.1-preview.304]" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.12.0]" />
   </ItemGroup>
 

--- a/src/Ayaka.Nuke/DotNet/ICanDotNetPush.cs
+++ b/src/Ayaka.Nuke/DotNet/ICanDotNetPush.cs
@@ -53,7 +53,7 @@ public interface ICanDotNetPush
         => (dotnet, packagePath) => dotnet;
 
     /// <summary>
-    ///     Gets all NuGet packages.
+    ///     Gets all NuGet packages to push.
     /// </summary>
     /// <remarks>
     ///     If not overridden, all <c>*.nupkg</c> files in the <see cref="IHavePackageArtifacts.PackagesDirectory" /> are
@@ -62,7 +62,7 @@ public interface ICanDotNetPush
     ///         Please note that symbols packages present in the package directory are pushed automatically.
     ///     </para>
     /// </remarks>
-    IEnumerable<AbsolutePath> NuGetPackages => PackagesDirectory.GlobFiles("*.nupkg");
+    IEnumerable<AbsolutePath> NuGetPackagesToPush => PackagesDirectory.GlobFiles("*.nupkg");
 
     /// <inheritdoc />
     Target IHaveDotNetPushTarget.DotNetPush => target => target
@@ -75,7 +75,7 @@ public interface ICanDotNetPush
                 dotnet => dotnet
                     .Apply(DotNetPushSettingsBase)
                     .Apply(DotNetPushSettings)
-                    .CombineWith(NuGetPackages, (d, f) => d
+                    .CombineWith(NuGetPackagesToPush, (d, f) => d
                         .Apply(DotNetPushPackageSettingsBase, f)
                         .Apply(DotNetPushPackageSettings, f)),
                 degreeOfParallelism: 5,

--- a/src/Ayaka.Nuke/DotNetValidate/DotNetValidateLocalPackageSettings.cs
+++ b/src/Ayaka.Nuke/DotNetValidate/DotNetValidateLocalPackageSettings.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.DotNetValidate;
+
+using global::Nuke.Common.Tooling;
+
+/// <summary>
+///     Provides settings for validating a local NuGet package using <c>dotnet-validate</c> CLI tool.
+/// </summary>
+[Serializable]
+public class DotNetValidateLocalPackageSettings : ToolSettings
+{
+    /// <summary>
+    ///     Gets the path to the executable of <c>dotnet-validate</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to <see cref="DotNetValidateTasks.DotNetValidatePath" />.
+    /// </remarks>
+    public override string ProcessToolPath => base.ProcessToolPath ?? DotNetValidateTasks.DotNetValidatePath;
+
+    /// <summary>
+    ///     Gets the process logger
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to <see cref="DotNetValidateTasks.DotNetValidateLogger" />.
+    /// </remarks>
+    public override Action<OutputType, string> ProcessLogger =>
+        base.ProcessLogger ?? DotNetValidateTasks.DotNetValidateLogger;
+
+    /// <summary>
+    ///     Gets the process exit handler.
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to <see cref="DotNetValidateTasks.DotNetValidateExitHandler" />.
+    /// </remarks>
+    public override Action<ToolSettings, IProcess> ProcessExitHandler =>
+        base.ProcessExitHandler ?? DotNetValidateTasks.DotNetValidateExitHandler;
+
+    /// <summary>
+    ///     Gets the path to the package to validate.
+    /// </summary>
+    public virtual string? PackagePath { get; internal set; }
+
+    /// <inheritdoc />
+    protected override Arguments ConfigureProcessArguments(Arguments arguments)
+    {
+        _ = arguments
+            .Add("dotnet-validate package local")
+            .Add("{value}", PackagePath);
+
+        return base.ConfigureProcessArguments(arguments);
+    }
+}

--- a/src/Ayaka.Nuke/DotNetValidate/DotNetValidateLocalPackageSettingsExtensions.cs
+++ b/src/Ayaka.Nuke/DotNetValidate/DotNetValidateLocalPackageSettingsExtensions.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.DotNetValidate;
+
+using global::Nuke.Common.Tooling;
+
+/// <summary>
+///     Extension methods for <see cref="DotNetValidateLocalPackageSettings" />.
+/// </summary>
+public static class DotNetValidateLocalPackageSettingsExtensions
+{
+    /// <summary>
+    ///     Sets the path to the package to validate.
+    /// </summary>
+    /// <param name="toolSettings">The settings instance to adjust.</param>
+    /// <param name="packagePath">The path to the package to validate.</param>
+    public static T SetPackagePath<T>(this T toolSettings, string packagePath)
+        where T : DotNetValidateLocalPackageSettings
+    {
+        toolSettings = toolSettings.NewInstance();
+        toolSettings.PackagePath = packagePath;
+
+        return toolSettings;
+    }
+
+    /// <summary>
+    ///     Resets the path of the package to validate to <c>null</c>.
+    /// </summary>
+    /// <param name="toolSettings">The settings instance to adjust.</param>
+    public static T ResetPackagePath<T>(this T toolSettings)
+        where T : DotNetValidateLocalPackageSettings
+    {
+        toolSettings = toolSettings.NewInstance();
+        toolSettings.PackagePath = null;
+
+        return toolSettings;
+    }
+}

--- a/src/Ayaka.Nuke/DotNetValidate/DotNetValidateRemotePackageSettings.cs
+++ b/src/Ayaka.Nuke/DotNetValidate/DotNetValidateRemotePackageSettings.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.DotNetValidate;
+
+using global::Nuke.Common.Tooling;
+
+/// <summary>
+///     Provides settings for validating a remote NuGet package using <c>dotnet-validate</c> CLI tool.
+/// </summary>
+[Serializable]
+public class DotNetValidateRemotePackageSettings : ToolSettings
+{
+    /// <summary>
+    ///     Gets the path to the executable of <c>dotnet-validate</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to <see cref="DotNetValidateTasks.DotNetValidatePath" />.
+    /// </remarks>
+    public override string ProcessToolPath => base.ProcessToolPath ?? DotNetValidateTasks.DotNetValidatePath;
+
+    /// <summary>
+    ///     Gets the process logger
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to <see cref="DotNetValidateTasks.DotNetValidateLogger" />.
+    /// </remarks>
+    public override Action<OutputType, string> ProcessLogger =>
+        base.ProcessLogger ?? DotNetValidateTasks.DotNetValidateLogger;
+
+    /// <summary>
+    ///     Gets the process exit handler.
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to <see cref="DotNetValidateTasks.DotNetValidateExitHandler" />.
+    /// </remarks>
+    public override Action<ToolSettings, IProcess> ProcessExitHandler =>
+        base.ProcessExitHandler ?? DotNetValidateTasks.DotNetValidateExitHandler;
+
+    /// <summary>
+    ///     Gets the identifier of the package to validate.
+    /// </summary>
+    public virtual string? PackageId { get; internal set; }
+
+    /// <summary>
+    ///     Gets the optional version of the package to validate.
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to the latest package version.
+    /// </remarks>
+    public virtual string? PackageVersion { get; internal set; }
+
+    /// <summary>
+    ///     Gets the directory from where the NuGet configuration file is loaded.
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to the current directory.
+    /// </remarks>
+    public virtual string? ConfigDirectory { get; internal set; }
+
+    /// <inheritdoc />
+    protected override Arguments ConfigureProcessArguments(Arguments arguments)
+    {
+        _ = arguments
+            .Add("dotnet-validate package remote")
+            .Add("{value}", PackageId)
+            .Add("--version {value}", PackageVersion)
+            .Add("--nuget-config-directory {value}", ConfigDirectory);
+
+        return base.ConfigureProcessArguments(arguments);
+    }
+}

--- a/src/Ayaka.Nuke/DotNetValidate/DotNetValidateRemotePackageSettingsExtensions.cs
+++ b/src/Ayaka.Nuke/DotNetValidate/DotNetValidateRemotePackageSettingsExtensions.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.DotNetValidate;
+
+using global::Nuke.Common.Tooling;
+
+/// <summary>
+///     Extension methods for <see cref="DotNetValidateRemotePackageSettings" />.
+/// </summary>
+public static class DotNetValidateRemotePackageSettingsExtensions
+{
+    /// <summary>
+    ///     Sets the identifier of the package to validate.
+    /// </summary>
+    /// <param name="toolSettings">The settings instance to adjust.</param>
+    /// <param name="packageId">The identifier of the package to validate.</param>
+    public static T SetPackageId<T>(this T toolSettings, string packageId)
+        where T : DotNetValidateRemotePackageSettings
+    {
+        toolSettings = toolSettings.NewInstance();
+        toolSettings.PackageId = packageId;
+        return toolSettings;
+    }
+
+    /// <summary>
+    ///     Resets the identifier of the package to validate to <c>null</c>.
+    /// </summary>
+    /// <param name="toolSettings">The settings instance to adjust.</param>
+    public static T ResetPackageId<T>(this T toolSettings)
+        where T : DotNetValidateRemotePackageSettings
+    {
+        toolSettings = toolSettings.NewInstance();
+        toolSettings.PackageId = null;
+        return toolSettings;
+    }
+
+    /// <summary>
+    ///     Sets the version of the package to validate.
+    /// </summary>
+    /// <param name="toolSettings">The settings instance to adjust.</param>
+    /// <param name="packageVersion">The version of the package to validate.</param>
+    public static T SetPackageVersion<T>(this T toolSettings, string packageVersion)
+        where T : DotNetValidateRemotePackageSettings
+    {
+        toolSettings = toolSettings.NewInstance();
+        toolSettings.PackageVersion = packageVersion;
+        return toolSettings;
+    }
+
+    /// <summary>
+    ///     Resets the version of the package to validate to <c>null</c>.
+    /// </summary>
+    /// <param name="toolSettings">The settings instance to adjust.</param>
+    public static T ResetPackageVersion<T>(this T toolSettings)
+        where T : DotNetValidateRemotePackageSettings
+    {
+        toolSettings = toolSettings.NewInstance();
+        toolSettings.PackageVersion = null;
+        return toolSettings;
+    }
+
+    /// <summary>
+    ///     Sets the directory from where the NuGet configuration file is loaded.
+    /// </summary>
+    /// <param name="toolSettings">The settings instance to adjust.</param>
+    /// <param name="configFile">The directory from where the NuGet configuration file is loaded.</param>
+    public static T SetConfigDirectory<T>(this T toolSettings, string configFile)
+        where T : DotNetValidateRemotePackageSettings
+    {
+        toolSettings = toolSettings.NewInstance();
+        toolSettings.ConfigDirectory = configFile;
+        return toolSettings;
+    }
+
+    /// <summary>
+    ///     Resets the directory from where the NuGet configuration file is loaded to <c>null</c>.
+    /// </summary>
+    /// <param name="toolSettings">The settings instance to adjust.</param>
+    public static T ResetConfigDirectory<T>(this T toolSettings)
+        where T : DotNetValidateRemotePackageSettings
+    {
+        toolSettings = toolSettings.NewInstance();
+        toolSettings.ConfigDirectory = null;
+        return toolSettings;
+    }
+}

--- a/src/Ayaka.Nuke/DotNetValidate/DotNetValidateTasks.cs
+++ b/src/Ayaka.Nuke/DotNetValidate/DotNetValidateTasks.cs
@@ -1,0 +1,201 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.DotNetValidate;
+
+using global::Nuke.Common.Tooling;
+
+/// <summary>
+///     Provides tasks for validating NuGet packages using <c>dotnet-validate</c> CLI tool.
+/// </summary>
+[NuGetPackageRequirement(DotNetValidatePackageId)]
+public class DotNetValidateTasks
+    : IRequireNuGetPackage
+{
+    /// <summary>
+    ///     The identifier of the <c>dotnet-validate</c> NuGet package.
+    /// </summary>
+    public const string DotNetValidatePackageId = "dotnet-validate";
+
+    /// <summary>
+    ///     Gets the path to the executable of <c>dotnet-validate</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Tries to resolve by environment variable <c>DOTNET_VALIDATE_EXE</c> and if not found, by <c>dotnet-validate.dll</c>
+    ///     from within the NuGet package.
+    /// </remarks>
+    public static string DotNetValidatePath
+        => ToolPathResolver.TryGetEnvironmentExecutable("DOTNET_VALIDATE_EXE")
+           ?? NuGetToolPathResolver.GetPackageExecutable(DotNetValidatePackageId, "dotnet-validate.dll");
+
+    /// <summary>
+    ///     Gets or sets default process logger for <c>dotnet-validate</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to <see cref="ProcessTasks.DefaultLogger" />.
+    /// </remarks>
+    public static Action<OutputType, string> DotNetValidateLogger { get; set; } = ProcessTasks.DefaultLogger;
+
+    /// <summary>
+    ///     Gets or sets the default process exit handler for <c>dotnet-validate</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to <see cref="ProcessTasks.DefaultExitHandler" />.
+    /// </remarks>
+    public static Action<ToolSettings?, IProcess> DotNetValidateExitHandler { get; set; } =
+        ProcessTasks.DefaultExitHandler;
+
+    /// <summary>
+    ///     Validates NuGet package health using <c>dotnet-validate</c> CLI tool.
+    ///     Ensures your package meets the .NET foundation's guidelines for secure packages.
+    /// </summary>
+    /// <remarks>
+    ///     For more details, visit the
+    ///     <see href="https://github.com/NuGetPackageExplorer/NuGetPackageExplorer">official website</see>.
+    /// </remarks>
+    /// <param name="arguments">The process arguments.</param>
+    /// <param name="workingDirectory">The working directory of the process.</param>
+    /// <param name="environmentVariables">The environment variables to assign for the process.</param>
+    /// <param name="timeout">The time to wait for the process to exit.</param>
+    /// <param name="logOutput">Indicates whether to log output or not.</param>
+    /// <param name="logInvocation">Indicates whether to log the invocation of the process.</param>
+    /// <param name="logger">The logger to use for the process.</param>
+    /// <param name="exitHandler">The exit handler to use for the process.</param>
+    /// <returns>A <see cref="IReadOnlyCollection{Output}" /> containing the process output.</returns>
+    public static IReadOnlyCollection<Output> DotNetValidate(
+        ArgumentStringHandler arguments,
+        string? workingDirectory = null,
+        IReadOnlyDictionary<string, string>? environmentVariables = null,
+        int? timeout = null,
+        bool? logOutput = null,
+        bool? logInvocation = null,
+        Action<OutputType, string>? logger = null,
+        Action<IProcess>? exitHandler = null)
+    {
+        using var process = ProcessTasks.StartProcess(
+            DotNetValidatePath,
+            arguments,
+            workingDirectory,
+            environmentVariables,
+            timeout,
+            logOutput,
+            logInvocation,
+            logger ?? DotNetValidateLogger);
+
+        (exitHandler ?? (p => DotNetValidateExitHandler.Invoke(arg1: null, p)))
+            .Invoke(process.AssertWaitForExit());
+
+        return process.Output;
+    }
+
+    /// <summary>
+    ///     Validates NuGet package health for a local package file using <c>dotnet-validate</c> CLI tool.
+    ///     Ensures your package meets the .NET foundation's guidelines for secure packages.
+    /// </summary>
+    /// <remarks>
+    ///     For more details, visit the
+    ///     <see href="https://github.com/NuGetPackageExplorer/NuGetPackageExplorer">official website</see>.
+    /// </remarks>
+    /// <param name="toolSettings">The settings to use for the process.</param>
+    /// <returns>A <see cref="IReadOnlyCollection{Output}" /> containing the process output.</returns>
+    public static IReadOnlyCollection<Output> DotNetValidateLocalPackage(DotNetValidateLocalPackageSettings toolSettings)
+    {
+        using var process = ProcessTasks.StartProcess(toolSettings);
+
+        toolSettings.ProcessExitHandler.Invoke(toolSettings, process.AssertWaitForExit());
+
+        return process.Output;
+    }
+
+    /// <summary>
+    ///     Validates NuGet package health for a local package file using <c>dotnet-validate</c> CLI tool.
+    ///     Ensures your package meets the .NET foundation's guidelines for secure packages.
+    /// </summary>
+    /// <remarks>
+    ///     For more details, visit the
+    ///     <see href="https://github.com/NuGetPackageExplorer/NuGetPackageExplorer">official website</see>.
+    /// </remarks>
+    /// <param name="configurator">A method to use for configuring the setting of the process.</param>
+    /// <returns>A <see cref="IReadOnlyCollection{Output}" /> containing the process output.</returns>
+    public static IReadOnlyCollection<Output> DotNetValidateLocalPackage(Configure<DotNetValidateLocalPackageSettings> configurator)
+        => DotNetValidateLocalPackage(configurator(new DotNetValidateLocalPackageSettings()));
+
+    /// <summary>
+    ///     Validates NuGet package health for a local package file using <c>dotnet-validate</c> CLI tool.
+    ///     Ensures your package meets the .NET foundation's guidelines for secure packages.
+    /// </summary>
+    /// <remarks>
+    ///     For more details, visit the
+    ///     <see href="https://github.com/NuGetPackageExplorer/NuGetPackageExplorer">official website</see>.
+    /// </remarks>
+    /// <param name="configurator">A method to use for configuring settings of multiple invocations of the process.</param>
+    /// <param name="degreeOfParallelism">The degree of parallelism when invoking the process.</param>
+    /// <param name="completeOnFailure">Indicates whether continue invocation on failures or not.</param>
+    /// <returns>A <see cref="IEnumerable{T}" /> containing the settings and output of each invocation of the process.</returns>
+    public static
+        IEnumerable<(DotNetValidateLocalPackageSettings Settings, IReadOnlyCollection<Output> Output)>
+        DotNetValidateLocalPackage(
+            CombinatorialConfigure<DotNetValidateLocalPackageSettings> configurator,
+            int degreeOfParallelism = 1,
+            bool completeOnFailure = false)
+        => configurator.Invoke(
+            DotNetValidateLocalPackage,
+            DotNetValidateLogger,
+            degreeOfParallelism,
+            completeOnFailure);
+
+    /// <summary>
+    ///     Validates NuGet package health for a remote package using <c>dotnet-validate</c> CLI tool.
+    ///     Ensures your package meets the .NET foundation's guidelines for secure packages.
+    /// </summary>
+    /// <remarks>
+    ///     For more details, visit the
+    ///     <see href="https://github.com/NuGetPackageExplorer/NuGetPackageExplorer">official website</see>.
+    /// </remarks>
+    /// <param name="toolSettings">The settings to use for the process.</param>
+    /// <returns>A <see cref="IReadOnlyCollection{Output}" /> containing the process output.</returns>
+    public static IReadOnlyCollection<Output> DotNetValidateRemotePackage(DotNetValidateRemotePackageSettings toolSettings)
+    {
+        using var process = ProcessTasks.StartProcess(toolSettings);
+
+        toolSettings.ProcessExitHandler.Invoke(toolSettings, process.AssertWaitForExit());
+
+        return process.Output;
+    }
+
+    /// <summary>
+    ///     Validates NuGet package health for a remote package using <c>dotnet-validate</c> CLI tool.
+    ///     Ensures your package meets the .NET foundation's guidelines for secure packages.
+    /// </summary>
+    /// <remarks>
+    ///     For more details, visit the
+    ///     <see href="https://github.com/NuGetPackageExplorer/NuGetPackageExplorer">official website</see>.
+    /// </remarks>
+    /// <param name="configurator">A method to use for configuring the setting of the process.</param>
+    /// <returns>A <see cref="IReadOnlyCollection{Output}" /> containing the process output.</returns>
+    public static IReadOnlyCollection<Output> DotNetValidateRemotePackage(Configure<DotNetValidateRemotePackageSettings> configurator)
+        => DotNetValidateRemotePackage(configurator(new DotNetValidateRemotePackageSettings()));
+
+    /// <summary>
+    ///     Validates NuGet package health for a remote package using <c>dotnet-validate</c> CLI tool.
+    ///     Ensures your package meets the .NET foundation's guidelines for secure packages.
+    /// </summary>
+    /// <remarks>
+    ///     For more details, visit the
+    ///     <see href="https://github.com/NuGetPackageExplorer/NuGetPackageExplorer">official website</see>.
+    /// </remarks>
+    /// <param name="configurator">A method to use for configuring settings of multiple invocations of the process.</param>
+    /// <param name="degreeOfParallelism">The degree of parallelism when invoking the process.</param>
+    /// <param name="completeOnFailure">Indicates whether continue invocation on failures or not.</param>
+    /// <returns>A <see cref="IEnumerable{T}" /> containing the settings and output of each invocation of the process.</returns>
+    public static
+        IEnumerable<(DotNetValidateRemotePackageSettings Settings, IReadOnlyCollection<Output> Output)>
+        DotNetValidateRemotePackage(
+            CombinatorialConfigure<DotNetValidateRemotePackageSettings> configurator,
+            int degreeOfParallelism = 1,
+            bool completeOnFailure = false)
+        => configurator.Invoke(
+            DotNetValidateRemotePackage,
+            DotNetValidateLogger,
+            degreeOfParallelism,
+            completeOnFailure);
+}

--- a/src/Ayaka.Nuke/DotNetValidate/ICanDotNetValidate.cs
+++ b/src/Ayaka.Nuke/DotNetValidate/ICanDotNetValidate.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.DotNetValidate;
+
+using global::Nuke.Common;
+using global::Nuke.Common.IO;
+using global::Nuke.Common.Tooling;
+
+/// <summary>
+///     Provides a target for validating NuGet packages using <c>dotnet-validate</c> CLI tool to the
+///     <see cref="INukeBuild" />.
+/// </summary>
+public interface ICanDotNetValidate
+    : ICan,
+        IHavePackageArtifacts,
+        IHaveDotNetValidateTarget
+{
+    /// <summary>
+    ///     Gets the base settings for validating a specific NuGet package.
+    /// </summary>
+    sealed Configure<DotNetValidateLocalPackageSettings, AbsolutePath> DotNetValidatePackageSettingsBase
+        => (dotnetValidate, packagePath) => dotnetValidate
+            .SetPackagePath(packagePath);
+
+    /// <summary>
+    ///     Gets the additional settings for validating a specific NuGet package.
+    /// </summary>
+    /// <remarks>
+    ///     Override this to provide additional settings for the <see cref="IHaveDotNetValidateTarget.DotNetValidate" />
+    ///     target.
+    /// </remarks>
+    Configure<DotNetValidateLocalPackageSettings, AbsolutePath> DotNetValidatePackageSettings
+        => (dotnetValidate, packagePath) => dotnetValidate;
+
+    /// <summary>
+    ///     Gets all NuGet packages to validate.
+    /// </summary>
+    /// <remarks>
+    ///     If not overridden, all <c>*.nupkg</c> files in the <see cref="IHavePackageArtifacts.PackagesDirectory" /> are
+    ///     considered packages.
+    /// </remarks>
+    IEnumerable<AbsolutePath> NuGetPackagesToValidate => PackagesDirectory.GlobFiles("*.nupkg");
+
+    /// <inheritdoc />
+    Target IHaveDotNetValidateTarget.DotNetValidate => target => target
+        .Description("Validates all NuGet packages using 'dotnet-validate' CLI tool")
+        .Unlisted()
+        .OnlyWhenStatic(() => IsServerBuild)
+        .Executes(() =>
+        {
+            _ = DotNetValidateTasks.DotNetValidateLocalPackage(
+                dotnetValidate => dotnetValidate
+                    .CombineWith(NuGetPackagesToValidate, (d, f) => d
+                        .Apply(DotNetValidatePackageSettingsBase, f)
+                        .Apply(DotNetValidatePackageSettings, f)),
+                degreeOfParallelism: 1,
+                completeOnFailure: true);
+        });
+}

--- a/src/Ayaka.Nuke/DotNetValidate/IHaveDotNetValidateTarget.cs
+++ b/src/Ayaka.Nuke/DotNetValidate/IHaveDotNetValidateTarget.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.DotNetValidate;
+
+using global::Nuke.Common;
+
+/// <summary>
+///     Indicates that a <see cref="INukeBuild" /> has a target for validating NuGet packages.
+/// </summary>
+public interface IHaveDotNetValidateTarget
+    : IHave
+{
+    /// <summary>
+    ///     Gets the target for validating NuGet packages.
+    /// </summary>
+    Target DotNetValidate { get; }
+}

--- a/src/Ayaka.Nuke/PublicAPI.Unshipped.txt
+++ b/src/Ayaka.Nuke/PublicAPI.Unshipped.txt
@@ -12,7 +12,7 @@ Ayaka.Nuke.DotNet.ICanDotNetPush.DotNetPushPackageSettings.get -> Nuke.Common.To
 Ayaka.Nuke.DotNet.ICanDotNetPush.DotNetPushPackageSettingsBase.get -> Nuke.Common.Tooling.Configure<Nuke.Common.Tools.DotNet.DotNetNuGetPushSettings!, Nuke.Common.IO.AbsolutePath!>!
 Ayaka.Nuke.DotNet.ICanDotNetPush.DotNetPushSettings.get -> Nuke.Common.Tooling.Configure<Nuke.Common.Tools.DotNet.DotNetNuGetPushSettings!>!
 Ayaka.Nuke.DotNet.ICanDotNetPush.DotNetPushSettingsBase.get -> Nuke.Common.Tooling.Configure<Nuke.Common.Tools.DotNet.DotNetNuGetPushSettings!>!
-Ayaka.Nuke.DotNet.ICanDotNetPush.NuGetPackages.get -> System.Collections.Generic.IEnumerable<Nuke.Common.IO.AbsolutePath!>!
+Ayaka.Nuke.DotNet.ICanDotNetPush.NuGetPackagesToPush.get -> System.Collections.Generic.IEnumerable<Nuke.Common.IO.AbsolutePath!>!
 Ayaka.Nuke.DotNet.ICanDotNetRestore
 Ayaka.Nuke.DotNet.ICanDotNetRestore.DotNetRestoreSettings.get -> Nuke.Common.Tooling.Configure<Nuke.Common.Tools.DotNet.DotNetRestoreSettings!>!
 Ayaka.Nuke.DotNet.ICanDotNetRestore.DotNetRestoreSettingsBase.get -> Nuke.Common.Tooling.Configure<Nuke.Common.Tools.DotNet.DotNetRestoreSettings!>!
@@ -35,6 +35,20 @@ Ayaka.Nuke.DotNet.IHaveDotNetRestoreTarget
 Ayaka.Nuke.DotNet.IHaveDotNetRestoreTarget.DotNetRestore.get -> Nuke.Common.Target!
 Ayaka.Nuke.DotNet.IHaveDotNetTestTarget
 Ayaka.Nuke.DotNet.IHaveDotNetTestTarget.DotNetTest.get -> Nuke.Common.Target!
+Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettings
+Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettings.DotNetValidateLocalPackageSettings() -> void
+Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettingsExtensions
+Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings
+Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.DotNetValidateRemotePackageSettings() -> void
+Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettingsExtensions
+Ayaka.Nuke.DotNetValidate.DotNetValidateTasks
+Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidateTasks() -> void
+Ayaka.Nuke.DotNetValidate.ICanDotNetValidate
+Ayaka.Nuke.DotNetValidate.ICanDotNetValidate.DotNetValidatePackageSettings.get -> Nuke.Common.Tooling.Configure<Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettings!, Nuke.Common.IO.AbsolutePath!>!
+Ayaka.Nuke.DotNetValidate.ICanDotNetValidate.DotNetValidatePackageSettingsBase.get -> Nuke.Common.Tooling.Configure<Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettings!, Nuke.Common.IO.AbsolutePath!>!
+Ayaka.Nuke.DotNetValidate.ICanDotNetValidate.NuGetPackagesToValidate.get -> System.Collections.Generic.IEnumerable<Nuke.Common.IO.AbsolutePath!>!
+Ayaka.Nuke.DotNetValidate.IHaveDotNetValidateTarget
+Ayaka.Nuke.DotNetValidate.IHaveDotNetValidateTarget.DotNetValidate.get -> Nuke.Common.Target!
 Ayaka.Nuke.Extensions
 Ayaka.Nuke.ICan
 Ayaka.Nuke.ICanClean
@@ -62,8 +76,41 @@ Ayaka.Nuke.IHaveTests.TestsDirectory.get -> Nuke.Common.IO.AbsolutePath!
 Ayaka.Nuke.NuGet.IHaveNuGetConfiguration
 Ayaka.Nuke.NuGet.IHaveNuGetConfiguration.NuGetApiKey.get -> string?
 Ayaka.Nuke.NuGet.IHaveNuGetConfiguration.NuGetSource.get -> string!
+const Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidatePackageId = "dotnet-validate" -> string!
 const Ayaka.Nuke.NuGet.IHaveNuGetConfiguration.DefaultNuGetSource = "https://api.nuget.org/v3/index.json" -> string!
+override Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettings.ConfigureProcessArguments(Nuke.Common.Tooling.Arguments! arguments) -> Nuke.Common.Tooling.Arguments!
+override Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettings.ProcessExitHandler.get -> System.Action<Nuke.Common.Tooling.ToolSettings!, Nuke.Common.Tooling.IProcess!>!
+override Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettings.ProcessLogger.get -> System.Action<Nuke.Common.Tooling.OutputType, string!>!
+override Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettings.ProcessToolPath.get -> string!
+override Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.ConfigureProcessArguments(Nuke.Common.Tooling.Arguments! arguments) -> Nuke.Common.Tooling.Arguments!
+override Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.ProcessExitHandler.get -> System.Action<Nuke.Common.Tooling.ToolSettings!, Nuke.Common.Tooling.IProcess!>!
+override Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.ProcessLogger.get -> System.Action<Nuke.Common.Tooling.OutputType, string!>!
+override Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.ProcessToolPath.get -> string!
 static Ayaka.Nuke.DotNet.Configuration.Debug -> Ayaka.Nuke.DotNet.Configuration!
 static Ayaka.Nuke.DotNet.Configuration.implicit operator string!(Ayaka.Nuke.DotNet.Configuration! configuration) -> string!
 static Ayaka.Nuke.DotNet.Configuration.Release -> Ayaka.Nuke.DotNet.Configuration!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettingsExtensions.ResetPackagePath<T>(this T! toolSettings) -> T!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettingsExtensions.SetPackagePath<T>(this T! toolSettings, string! packagePath) -> T!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettingsExtensions.ResetConfigDirectory<T>(this T! toolSettings) -> T!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettingsExtensions.ResetPackageId<T>(this T! toolSettings) -> T!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettingsExtensions.ResetPackageVersion<T>(this T! toolSettings) -> T!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettingsExtensions.SetConfigDirectory<T>(this T! toolSettings, string! configFile) -> T!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettingsExtensions.SetPackageId<T>(this T! toolSettings, string! packageId) -> T!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettingsExtensions.SetPackageVersion<T>(this T! toolSettings, string! packageVersion) -> T!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidate(Nuke.Common.Tooling.ArgumentStringHandler arguments, string? workingDirectory = null, System.Collections.Generic.IReadOnlyDictionary<string!, string!>? environmentVariables = null, int? timeout = null, bool? logOutput = null, bool? logInvocation = null, System.Action<Nuke.Common.Tooling.OutputType, string!>? logger = null, System.Action<Nuke.Common.Tooling.IProcess!>? exitHandler = null) -> System.Collections.Generic.IReadOnlyCollection<Nuke.Common.Tooling.Output>!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidateExitHandler.get -> System.Action<Nuke.Common.Tooling.ToolSettings?, Nuke.Common.Tooling.IProcess!>!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidateExitHandler.set -> void
+static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidateLocalPackage(Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettings! toolSettings) -> System.Collections.Generic.IReadOnlyCollection<Nuke.Common.Tooling.Output>!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidateLocalPackage(Nuke.Common.Tooling.CombinatorialConfigure<Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettings!>! configurator, int degreeOfParallelism = 1, bool completeOnFailure = false) -> System.Collections.Generic.IEnumerable<(Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettings! Settings, System.Collections.Generic.IReadOnlyCollection<Nuke.Common.Tooling.Output>! Output)>!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidateLocalPackage(Nuke.Common.Tooling.Configure<Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettings!>! configurator) -> System.Collections.Generic.IReadOnlyCollection<Nuke.Common.Tooling.Output>!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidateLogger.get -> System.Action<Nuke.Common.Tooling.OutputType, string!>!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidateLogger.set -> void
+static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidatePath.get -> string!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidateRemotePackage(Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings! toolSettings) -> System.Collections.Generic.IReadOnlyCollection<Nuke.Common.Tooling.Output>!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidateRemotePackage(Nuke.Common.Tooling.CombinatorialConfigure<Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings!>! configurator, int degreeOfParallelism = 1, bool completeOnFailure = false) -> System.Collections.Generic.IEnumerable<(Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings! Settings, System.Collections.Generic.IReadOnlyCollection<Nuke.Common.Tooling.Output>! Output)>!
+static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidateRemotePackage(Nuke.Common.Tooling.Configure<Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings!>! configurator) -> System.Collections.Generic.IReadOnlyCollection<Nuke.Common.Tooling.Output>!
 static Ayaka.Nuke.Extensions.WhenNotNull<T, TObject>(this T settings, TObject? obj, System.Func<T, TObject, T>! configurator) -> T
+virtual Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettings.PackagePath.get -> string?
+virtual Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.ConfigDirectory.get -> string?
+virtual Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.PackageId.get -> string?
+virtual Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.PackageVersion.get -> string?

--- a/test/Ayaka.Nuke.Tests/Ayaka.Nuke.Tests.csproj
+++ b/test/Ayaka.Nuke.Tests/Ayaka.Nuke.Tests.csproj
@@ -4,6 +4,11 @@
     <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Until NUKE decides to switch to JSON for cloning settings -->
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Ayaka.Nuke\Ayaka.Nuke.csproj" />
   </ItemGroup>

--- a/test/Ayaka.Nuke.Tests/DotNetValidate/DotNetValidateLocalPackageSettingsExtensionsTest.cs
+++ b/test/Ayaka.Nuke.Tests/DotNetValidate/DotNetValidateLocalPackageSettingsExtensionsTest.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.Tests.DotNetValidate;
+
+using Ayaka.Nuke.DotNetValidate;
+
+public sealed class DotNetValidateLocalPackageSettingsExtensionsTest
+{
+    [Fact]
+    public void Does_set_PackagePath()
+    {
+        var original = new DotNetValidateLocalPackageSettings();
+
+        var actual = original.SetPackagePath("path/to/package");
+
+        actual.Should().NotBeSameAs(original);
+        original.PackagePath.Should().Be(expected: null);
+        actual.PackagePath.Should().Be("path/to/package");
+    }
+
+    [Fact]
+    public void Does_reset_PackagePath()
+    {
+        var original = new DotNetValidateLocalPackageSettings()
+            .SetPackagePath("path/to/package");
+
+        var actual = original.ResetPackagePath();
+
+        actual.Should().NotBeSameAs(original);
+        original.PackagePath.Should().Be("path/to/package");
+        actual.PackagePath.Should().Be(expected: null);
+    }
+}

--- a/test/Ayaka.Nuke.Tests/DotNetValidate/DotNetValidateLocalPackageSettingsTest.cs
+++ b/test/Ayaka.Nuke.Tests/DotNetValidate/DotNetValidateLocalPackageSettingsTest.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.Tests.DotNetValidate;
+
+using Ayaka.Nuke.DotNetValidate;
+
+public sealed class DotNetValidateLocalPackageSettingsTest
+{
+    [Theory]
+    [InlineData(null, "dotnet-validate package local")]
+    [InlineData("path/to/package", "dotnet-validate package local path/to/package")]
+    public void Does_configure_process_arguments(string? packagePath, string expectedArguments)
+    {
+        var settings = new DotNetValidateLocalPackageSettings()
+            .SetPackagePath(packagePath!);
+
+        var arguments = settings.GetProcessArguments();
+
+        arguments
+            .RenderForExecution()
+            .Should()
+            .BeEquivalentTo(expectedArguments);
+    }
+}

--- a/test/Ayaka.Nuke.Tests/DotNetValidate/DotNetValidateRemotePackageSettingsExtensionsTest.cs
+++ b/test/Ayaka.Nuke.Tests/DotNetValidate/DotNetValidateRemotePackageSettingsExtensionsTest.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.Tests.DotNetValidate;
+
+using Ayaka.Nuke.DotNetValidate;
+
+public sealed class DotNetValidateRemotePackageSettingsExtensionsTest
+{
+    [Fact]
+    public void Does_set_PackageId()
+    {
+        var original = new DotNetValidateRemotePackageSettings();
+
+        var actual = original.SetPackageId("mypackage");
+
+        actual.Should().NotBeSameAs(original);
+        original.PackageId.Should().Be(expected: null);
+        actual.PackageId.Should().Be("mypackage");
+    }
+
+    [Fact]
+    public void Does_reset_PackageId()
+    {
+        var original = new DotNetValidateRemotePackageSettings()
+            .SetPackageId("mypackage");
+
+        var actual = original.ResetPackageId();
+
+        actual.Should().NotBeSameAs(original);
+        original.PackageId.Should().Be("mypackage");
+        actual.PackageId.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_set_PackageVersion()
+    {
+        var original = new DotNetValidateRemotePackageSettings();
+
+        var actual = original.SetPackageVersion("1.2.3.4");
+
+        actual.Should().NotBeSameAs(original);
+        original.PackageVersion.Should().Be(expected: null);
+        actual.PackageVersion.Should().Be("1.2.3.4");
+    }
+
+    [Fact]
+    public void Does_reset_PackageVersion()
+    {
+        var original = new DotNetValidateRemotePackageSettings()
+            .SetPackageVersion("1.2.3.4");
+
+        var actual = original.ResetPackageVersion();
+
+        actual.Should().NotBeSameAs(original);
+        original.PackageVersion.Should().Be("1.2.3.4");
+        actual.PackageVersion.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_set_ConfigDirectory()
+    {
+        var original = new DotNetValidateRemotePackageSettings();
+
+        var actual = original.SetConfigDirectory("path/to/directory");
+
+        actual.Should().NotBeSameAs(original);
+        original.ConfigDirectory.Should().Be(expected: null);
+        actual.ConfigDirectory.Should().Be("path/to/directory");
+    }
+
+    [Fact]
+    public void Does_reset_ConfigDirectory()
+    {
+        var original = new DotNetValidateRemotePackageSettings()
+            .SetConfigDirectory("path/to/directory");
+
+        var actual = original.ResetConfigDirectory();
+
+        actual.Should().NotBeSameAs(original);
+        original.ConfigDirectory.Should().Be("path/to/directory");
+        actual.ConfigDirectory.Should().Be(expected: null);
+    }
+}

--- a/test/Ayaka.Nuke.Tests/DotNetValidate/DotNetValidateRemotePackageSettingsTest.cs
+++ b/test/Ayaka.Nuke.Tests/DotNetValidate/DotNetValidateRemotePackageSettingsTest.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.Tests.DotNetValidate;
+
+using Ayaka.Nuke.DotNetValidate;
+
+public sealed class DotNetValidateRemotePackageSettingsTest
+{
+    [Theory]
+    [InlineData(null, null, null, "dotnet-validate package remote")]
+    [InlineData("mypackage", null, null, "dotnet-validate package remote mypackage")]
+    [InlineData("mypackage", "1.2.3.4", null, "dotnet-validate package remote mypackage --version 1.2.3.4")]
+    [InlineData(
+        "mypackage",
+        "1.2.3.4",
+        "path/to/directory",
+        "dotnet-validate package remote mypackage --version 1.2.3.4 --nuget-config-directory path/to/directory")]
+    public void Does_configure_process_arguments(
+        string? packageId,
+        string? packageVersion,
+        string? configDirectory,
+        string expectedArguments)
+    {
+        var settings = new DotNetValidateRemotePackageSettings()
+            .SetPackageId(packageId!)
+            .SetPackageVersion(packageVersion!)
+            .SetConfigDirectory(configDirectory!);
+
+        var arguments = settings.GetProcessArguments();
+
+        arguments
+            .RenderForExecution()
+            .Should()
+            .BeEquivalentTo(expectedArguments);
+    }
+}


### PR DESCRIPTION
## Description

Adds support for the `dotnet-validate` CLI tool using NUKE tasks and targets.
Replaces the script based approach with the new target after packing NuGet packages.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Manual testing and some unit tests that cover the tool settings classes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
