### PR TITLE
feat: add support to create GitHub releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Download Packages
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: release
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  NUGET_PACKAGES: '${{ github.workspace }}/.nuget/packages'
+
+jobs:
+  release:
+      runs-on: ubuntu-latest
+
+      concurrency:
+        group: ${{ github.workflow }}
+        cancel-in-progress: false
+
+      permissions:
+        contents: write
+        issues: write
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+          with:
+            fetch-depth: 0
+
+        - name: NuGet Cache
+          uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+          with:
+            path: |
+              ${{ env.NUGET_PACKAGES }}
+              .nuke/temp
+            key: ${{ runner.os }}-nuget-${{ hashFiles('**/global.json', '**/*.csproj', '**/*.props') }}
+            restore-keys: |
+              ${{ runner.os }}-nuget-
+
+        - name: Setup .NET
+          uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4
+
+        - name: Restore .NET Tools
+          run: |
+            dotnet tool restore
+
+        - name: Create GitHub Release
+          run: |
+            dotnet nuke CreateRelease \
+              --github-token $GITHUB_TOKEN
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -22,6 +22,14 @@
             "Release"
           ]
         },
+        "GitHubBaseUrl": {
+          "type": "string"
+        },
+        "GitHubToken": {
+          "type": "string",
+          "description": "The GitHub API token",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
         "Help": {
           "type": "boolean",
           "description": "Shows the help text for this build assembly"
@@ -87,6 +95,7 @@
             "enum": [
               "Clean",
               "Compile",
+              "CreateRelease",
               "Default",
               "DotNetBuild",
               "DotNetPack",
@@ -94,6 +103,7 @@
               "DotNetRestore",
               "DotNetTest",
               "DotNetValidate",
+              "GitHubRelease",
               "Pack",
               "Publish",
               "Test"
@@ -112,6 +122,7 @@
             "enum": [
               "Clean",
               "Compile",
+              "CreateRelease",
               "Default",
               "DotNetBuild",
               "DotNetPack",
@@ -119,6 +130,7 @@
               "DotNetRestore",
               "DotNetTest",
               "DotNetValidate",
+              "GitHubRelease",
               "Pack",
               "Publish",
               "Test"

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -1,5 +1,10 @@
 <Project>
 
+  <!-- Packages for normal projects -->
+  <ItemGroup Condition="'$(IsTestProject)' != 'True'">
+    <PackageReference Include="Light.GuardClauses" Version="11.0.0" />
+  </ItemGroup>
+
   <!-- Packages for test projects -->
   <ItemGroup Condition="'$(IsTestProject)' == 'True'">
     <PackageReference Include="coverlet.collector" Version="6.0.2">

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -3,6 +3,7 @@
 using Ayaka.Nuke;
 using Ayaka.Nuke.DotNet;
 using Ayaka.Nuke.DotNetValidate;
+using Ayaka.Nuke.GitHub;
 using Ayaka.Nuke.NuGet;
 using Nuke.Common;
 using Nuke.Common.Tools.DotNet;
@@ -21,13 +22,15 @@ class Build
         IHavePackageArtifacts,
         IHaveDotNetConfiguration,
         IHaveNuGetConfiguration,
+        IHaveGitHubToken,
         ICanClean,
         ICanDotNetRestore,
         ICanDotNetBuild,
         ICanDotNetTest,
         ICanDotNetPack,
         ICanDotNetValidate,
-        ICanDotNetPush
+        ICanDotNetPush,
+        ICanGitHubRelease
 {
     public static int Main() => Execute<Build>(x => x.Default);
 
@@ -56,4 +59,8 @@ class Build
     Target Publish => target => target
         .Description("Publishes all NuGet packages in the Solution")
         .DependsOn<IHaveDotNetPushTarget>();
+
+    Target CreateRelease => target => target
+        .Description("Creates a new GitHub Release based on the current commit")
+        .DependsOn<IHaveGitHubReleaseTarget>();
 }

--- a/src/Ayaka.Nuke/Ayaka.Nuke.csproj
+++ b/src/Ayaka.Nuke/Ayaka.Nuke.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="8.0.0" />
+    <PackageReference Include="Octokit" Version="11.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Ayaka.Nuke/GitHub/GitHubReleaseNotesSettings.cs
+++ b/src/Ayaka.Nuke/GitHub/GitHubReleaseNotesSettings.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
 namespace Ayaka.Nuke.GitHub;
 
 using Light.GuardClauses;

--- a/src/Ayaka.Nuke/GitHub/GitHubReleaseNotesSettings.cs
+++ b/src/Ayaka.Nuke/GitHub/GitHubReleaseNotesSettings.cs
@@ -1,0 +1,53 @@
+namespace Ayaka.Nuke.GitHub;
+
+using Light.GuardClauses;
+
+/// <summary>
+///     Provides the settings for generating release notes for a GitHub release.
+/// </summary>
+[Serializable]
+public class GitHubReleaseNotesSettings : GitHubSettings
+{
+    /// <summary>
+    ///     Gets the tag name for the release.
+    /// </summary>
+    /// <remarks>
+    ///     This can be an existing tag or a new one.
+    /// </remarks>
+    public virtual string? Tag { get; internal set; }
+
+    /// <summary>
+    ///     Gets the commitish value that will be the target for the release's tag.
+    /// </summary>
+    /// <remarks>
+    ///     Required if the supplied <see cref="Tag" /> does not reference an existing tag. Ignored if the <see cref="Tag" />
+    ///     already exists.
+    /// </remarks>
+    public virtual string? TargetCommitish { get; internal set; }
+
+    /// <summary>
+    ///     Gets the name of the previous tag to use as the starting point for the release notes.
+    /// </summary>
+    /// <remarks>
+    ///     Use to manually specify the range for the set of changes considered as part this release.
+    /// </remarks>
+    public virtual string? PreviousTag { get; internal set; }
+
+    /// <summary>
+    ///     Gets the optional path to a file in the repository containing configuration settings used for generating the
+    ///     release notes.
+    /// </summary>
+    /// <remarks>
+    ///     If unspecified, the configuration file located in the repository at <c>.github/release.yml</c> or
+    ///     <c>.github/release.yaml</c> will be used. If that is not present, the default configuration will be used.
+    /// </remarks>
+    public virtual string? ConfigFile { get; internal set; }
+
+    /// <inheritdoc />
+    protected override void AssertValid()
+    {
+        base.AssertValid();
+
+        Tag.MustNotBeNullOrEmpty();
+    }
+}

--- a/src/Ayaka.Nuke/GitHub/GitHubReleaseNotesSettingsExtensions.cs
+++ b/src/Ayaka.Nuke/GitHub/GitHubReleaseNotesSettingsExtensions.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.GitHub;
+
+using global::Nuke.Common.Tooling;
+
+/// <summary>
+///     Extension methods for <see cref="GitHubReleaseNotesSettings" />.
+/// </summary>
+public static class GitHubReleaseNotesSettingsExtensions
+{
+    /// <summary>
+    ///     Sets the tag name for the release.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="tagName">The tag name for the release.</param>
+    public static T SetTag<T>(this T settings, string tagName)
+        where T : GitHubReleaseNotesSettings
+    {
+        settings = settings.NewInstance();
+        settings.Tag = tagName;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the tag name for the release to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetTag<T>(this T settings)
+        where T : GitHubReleaseNotesSettings
+    {
+        settings = settings.NewInstance();
+        settings.Tag = null;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Sets the commitish value that will be the target for the release's tag.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="targetCommitish">The commitish value that will be the target for the release's tag.</param>
+    public static T SetTargetCommitish<T>(this T settings, string targetCommitish)
+        where T : GitHubReleaseNotesSettings
+    {
+        settings = settings.NewInstance();
+        settings.TargetCommitish = targetCommitish;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the commitish value for the release's tag to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetTargetCommitish<T>(this T settings)
+        where T : GitHubReleaseNotesSettings
+    {
+        settings = settings.NewInstance();
+        settings.TargetCommitish = null;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Sets the name of the previous tag to use as the starting point for the release notes.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="previousTag">The name of the previous tag to use as the starting point for the release notes.</param>
+    public static T SetPreviousTag<T>(this T settings, string previousTag)
+        where T : GitHubReleaseNotesSettings
+    {
+        settings = settings.NewInstance();
+        settings.PreviousTag = previousTag;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the name of the previous tag to use to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetPreviousTag<T>(this T settings)
+        where T : GitHubReleaseNotesSettings
+    {
+        settings = settings.NewInstance();
+        settings.PreviousTag = null;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Sets the path to a file in the repository containing configuration settings used for generating the
+    ///     release notes.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="configFile">
+    ///     The optional path to a file in the repository containing configuration settings used for generating the
+    ///     release notes.
+    /// </param>
+    public static T SetConfigFile<T>(this T settings, string configFile)
+        where T : GitHubReleaseNotesSettings
+    {
+        settings = settings.NewInstance();
+        settings.ConfigFile = configFile;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the path to a file in the repository containing configuration settings used for generating the release notes
+    ///     to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetConfigFile<T>(this T settings)
+        where T : GitHubReleaseNotesSettings
+    {
+        settings = settings.NewInstance();
+        settings.ConfigFile = null;
+
+        return settings;
+    }
+}

--- a/src/Ayaka.Nuke/GitHub/GitHubReleaseSettings.cs
+++ b/src/Ayaka.Nuke/GitHub/GitHubReleaseSettings.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
 namespace Ayaka.Nuke.GitHub;
 
 using Light.GuardClauses;

--- a/src/Ayaka.Nuke/GitHub/GitHubReleaseSettings.cs
+++ b/src/Ayaka.Nuke/GitHub/GitHubReleaseSettings.cs
@@ -1,0 +1,82 @@
+namespace Ayaka.Nuke.GitHub;
+
+using Light.GuardClauses;
+
+/// <summary>
+///     Provides the settings for creating a GitHub release.
+/// </summary>
+[Serializable]
+public class GitHubReleaseSettings : GitHubSettings
+{
+    /// <summary>
+    ///     Gets the tag name for the release.
+    /// </summary>
+    /// <remarks>
+    ///     This can be an existing tag or a new one.
+    /// </remarks>
+    public virtual string? Tag { get; internal set; }
+
+    /// <summary>
+    ///     Gets the commitish value that will be the target for the release's tag.
+    /// </summary>
+    /// <remarks>
+    ///     Unused if the supplied <see cref="Tag" /> already exists. Defaults to the repository's default branch.
+    /// </remarks>
+    public virtual string? TargetCommitish { get; internal set; }
+
+    /// <summary>
+    ///     Gets the name of the release.
+    /// </summary>
+    public virtual string? Name { get; internal set; }
+
+    /// <summary>
+    ///     Gets the text describing the contents of the release.
+    /// </summary>
+    public virtual string? Body { get; internal set; }
+
+    /// <summary>
+    ///     Gets a value indicating whether the release is a draft.
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to <c>false</c>.
+    /// </remarks>
+    public virtual bool? Draft { get; internal set; }
+
+    /// <summary>
+    ///     Gets a value indicating whether the release is a pre-release.
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to <c>false</c>.
+    /// </remarks>
+    public virtual bool? PreRelease { get; internal set; }
+
+    /// <summary>
+    ///     Gets a value indicating whether to automatically generate release notes.
+    /// </summary>
+    /// <remarks>
+    ///     If <see cref="Body" /> is specified, the <see cref="Body" /> will be pre-pended to the automatically generated
+    ///     notes. Defaults to <c>false</c>.
+    /// </remarks>
+    public virtual bool? GenerateReleaseNotes { get; internal set; }
+
+    /// <summary>
+    ///     Gets the optional artifact paths to upload to the release.
+    /// </summary>
+    public virtual IReadOnlyList<string> ArtifactPaths => ArtifactPathsInternal.AsReadOnly();
+
+    internal List<string> ArtifactPathsInternal { get; set; } = [];
+
+    /// <inheritdoc />
+    protected override void AssertValid()
+    {
+        base.AssertValid();
+
+        Tag.MustNotBeNullOrEmpty();
+
+        if (GenerateReleaseNotes != true)
+        {
+            Name.MustNotBeNullOrEmpty();
+            Body.MustNotBeNullOrEmpty();
+        }
+    }
+}

--- a/src/Ayaka.Nuke/GitHub/GitHubReleaseSettingsExtensions.cs
+++ b/src/Ayaka.Nuke/GitHub/GitHubReleaseSettingsExtensions.cs
@@ -1,0 +1,227 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.GitHub;
+
+using global::Nuke.Common.Tooling;
+
+/// <summary>
+///     Extension methods for <see cref="GitHubReleaseSettings" />
+/// </summary>
+public static class GitHubReleaseSettingsExtensions
+{
+    /// <summary>
+    ///     Sets the tag name for the release.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="tagName">The tag name for the release.</param>
+    public static T SetTag<T>(this T settings, string tagName)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.Tag = tagName;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the tag name for the release to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetTag<T>(this T settings)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.Tag = null;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Sets the commitish value that will be the target for the release's tag.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="targetCommitish">The commitish value that will be the target for the release's tag.</param>
+    public static T SetTargetCommitish<T>(this T settings, string targetCommitish)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.TargetCommitish = targetCommitish;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the commitish value to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetTargetCommitish<T>(this T settings)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.TargetCommitish = null;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Sets the name of the release.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="name">The name of the release.</param>
+    public static T SetName<T>(this T settings, string name)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.Name = name;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the name of the release to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetName<T>(this T settings)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.Name = null;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Sets the text describing the contents of the release.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="body">The text describing the contents of the release.</param>
+    public static T SetBody<T>(this T settings, string body)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.Body = body;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the text describing the contents of the release to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetBody<T>(this T settings)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.Body = null;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Sets the value indicating whether the release is a draft.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="draft">The value indicating whether the release is a draft.</param>
+    public static T SetDraft<T>(this T settings, bool draft)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.Draft = draft;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the value indicating whether the release is a draft to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetDraft<T>(this T settings)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.Draft = null;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Sets the value indicating whether the release is a pre-release.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="preRelease">The value indicating whether the release is a pre-release.</param>
+    public static T SetPreRelease<T>(this T settings, bool preRelease)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.PreRelease = preRelease;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the value indicating whether the release is a pre-release to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetPreRelease<T>(this T settings)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.PreRelease = null;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Sets the value indicating whether to automatically generate release notes.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="generateReleaseNotes">The value indicating whether to automatically generate release notes.</param>
+    public static T SetGenerateReleaseNotes<T>(this T settings, bool generateReleaseNotes)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.GenerateReleaseNotes = generateReleaseNotes;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the value indicating whether to automatically generate release notes to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetGenerateReleaseNotes<T>(this T settings)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.GenerateReleaseNotes = null;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Adds a new artifact path to the release's artifacts.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="artifactPath">The artifact path to add to the release's artifacts.</param>
+    public static T AddArtifactPath<T>(this T settings, string artifactPath)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.ArtifactPathsInternal.Add(artifactPath);
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Clears all artifact paths from the release's artifacts.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ClearArtifactPaths<T>(this T settings)
+        where T : GitHubReleaseSettings
+    {
+        settings = settings.NewInstance();
+        settings.ArtifactPathsInternal.Clear();
+
+        return settings;
+    }
+}

--- a/src/Ayaka.Nuke/GitHub/GitHubSettings.cs
+++ b/src/Ayaka.Nuke/GitHub/GitHubSettings.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
 namespace Ayaka.Nuke.GitHub;
 
 using global::Nuke.Common.Tooling;

--- a/src/Ayaka.Nuke/GitHub/GitHubSettings.cs
+++ b/src/Ayaka.Nuke/GitHub/GitHubSettings.cs
@@ -1,0 +1,55 @@
+namespace Ayaka.Nuke.GitHub;
+
+using global::Nuke.Common.Tooling;
+using Light.GuardClauses;
+
+/// <summary>
+///     Provides the base settings for interacting with the GitHub API.
+/// </summary>
+[Serializable]
+public class GitHubSettings : ISettingsEntity
+{
+    /// <summary>
+    ///     Gets the account owner of the repository.
+    /// </summary>
+    /// <remarks>
+    ///     The name is not case sensitive.
+    /// </remarks>
+    public virtual string? RepositoryOwner { get; internal set; }
+
+    /// <summary>
+    ///     Gets the name of the repository without the .git extension.
+    /// </summary>
+    /// <remarks>
+    ///     The name is not case sensitive.
+    /// </remarks>
+    public virtual string? RepositoryName { get; internal set; }
+
+    /// <summary>
+    ///     Gets the GitHub token used to authenticate with the GitHub API.
+    /// </summary>
+    public virtual string? Token { get; internal set; }
+
+    /// <summary>
+    ///     Gets the base URL for the GitHub API.
+    /// </summary>
+    /// <remarks>
+    ///     Mainly used for GitHub enterprise.
+    /// </remarks>
+    public virtual string? BaseUrl { get; internal set; }
+
+    /// <summary>
+    ///     Validates this instance of GitHub settings.
+    /// </summary>
+    public void Validate() => AssertValid();
+
+    /// <summary>
+    ///     Asserts that the settings are valid.
+    /// </summary>
+    protected virtual void AssertValid()
+    {
+        RepositoryOwner.MustNotBeNullOrEmpty();
+        RepositoryName.MustNotBeNullOrEmpty();
+        Token.MustNotBeNullOrEmpty();
+    }
+}

--- a/src/Ayaka.Nuke/GitHub/GitHubSettingsExtensions.cs
+++ b/src/Ayaka.Nuke/GitHub/GitHubSettingsExtensions.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.GitHub;
+
+using global::Nuke.Common.Tooling;
+
+/// <summary>
+///     Extension methods for <see cref="GitHubSettings" />.
+/// </summary>
+public static class GitHubSettingsExtensions
+{
+    /// <summary>
+    ///     Sets the account owner of the repository.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="repositoryOwner">The account owner of the repository.</param>
+    public static T SetRepositoryOwner<T>(this T settings, string repositoryOwner)
+        where T : GitHubSettings
+    {
+        settings = settings.NewInstance();
+        settings.RepositoryOwner = repositoryOwner;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the account owner of the repository to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetRepositoryOwner<T>(this T settings)
+        where T : GitHubSettings
+    {
+        settings = settings.NewInstance();
+        settings.RepositoryOwner = null;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Sets the name of the repository without the .git extension.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="repositoryName">The name of the repository without the .git extension.</param>
+    public static T SetRepositoryName<T>(this T settings, string repositoryName)
+        where T : GitHubSettings
+    {
+        settings = settings.NewInstance();
+        settings.RepositoryName = repositoryName;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the name of the repository to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetRepositoryName<T>(this T settings)
+        where T : GitHubSettings
+    {
+        settings = settings.NewInstance();
+        settings.RepositoryName = null;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Sets the GitHub token used to authenticate with the GitHub API.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="token">The GitHub token used to authenticate with the GitHub API.</param>
+    public static T SetToken<T>(this T settings, string token)
+        where T : GitHubSettings
+    {
+        settings = settings.NewInstance();
+        settings.Token = token;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the GitHub token to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetToken<T>(this T settings)
+        where T : GitHubSettings
+    {
+        settings = settings.NewInstance();
+        settings.Token = null;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Sets the base URL for the GitHub API.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    /// <param name="baseUrl">The base URL for the GitHub API.</param>
+    public static T SetBaseUrl<T>(this T settings, string baseUrl)
+        where T : GitHubSettings
+    {
+        settings = settings.NewInstance();
+        settings.BaseUrl = baseUrl;
+
+        return settings;
+    }
+
+    /// <summary>
+    ///     Resets the base URL for the GitHub API to <c>null</c>.
+    /// </summary>
+    /// <param name="settings">The settings instance to adjust.</param>
+    public static T ResetBaseUrl<T>(this T settings)
+        where T : GitHubSettings
+    {
+        settings = settings.NewInstance();
+        settings.BaseUrl = null;
+
+        return settings;
+    }
+}

--- a/src/Ayaka.Nuke/GitHub/GitHubTasks.cs
+++ b/src/Ayaka.Nuke/GitHub/GitHubTasks.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.GitHub;
+
+using System.Reflection;
+using global::Nuke.Common.Tooling;
+using Octokit;
+using Serilog;
+
+/// <summary>
+///     Provides tasks for interacting with the GitHub API.
+/// </summary>
+public static class GitHubTasks
+{
+    /// <summary>
+    ///     Creates a new GitHub release using the GitHub API.
+    /// </summary>
+    /// <param name="settings">The settings to for creating the release.</param>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    public static async Task CreateRelease(GitHubReleaseSettings settings)
+    {
+        settings.Validate();
+
+        var client = CreateGitHubClient(settings.Token!, settings.BaseUrl);
+
+        Log.Debug("Checking whether release with tag '{TagName}' already exists...", settings.Tag);
+        
+        var existingReleases = await client.Repository.Release.GetAll(
+            settings.RepositoryOwner!,
+            settings.RepositoryName!);
+        
+        if (existingReleases.Any(x => x.TagName == settings.Tag))
+        {
+            Log.Warning("Release with tag '{TagName}' already exists. No GitHub release is created", settings.Tag);
+            return;
+        }
+
+        Log.Debug("Release with tag '{TagName}' not found", settings.Tag);
+
+        var newRelease = new NewRelease(settings.Tag)
+        {
+            TargetCommitish = settings.TargetCommitish,
+            Name = settings.Name,
+            Body = settings.Body,
+            Draft = settings.Draft ?? false,
+            Prerelease = settings.PreRelease ?? false,
+            GenerateReleaseNotes = settings.GenerateReleaseNotes ?? false
+        };
+
+        Log.Information("Creating release with tag '{TagName}'...", settings.Tag);
+        Log.Verbose("  Target commitish: {TargetCommitish}", newRelease.TargetCommitish);
+        Log.Verbose("  Name: {Name}", newRelease.Name);
+        Log.Verbose("  Body: {Body}", newRelease.Body);
+        Log.Verbose("  Draft: {Draft}", newRelease.Draft);
+        Log.Verbose("  Pre-release: {PreRelease}", newRelease.Prerelease);
+        Log.Verbose("  Generate release notes: {GenerateReleaseNotes}", newRelease.GenerateReleaseNotes);
+
+        var release = await client.Repository.Release.Create(
+            settings.RepositoryOwner!,
+            settings.RepositoryName!,
+            newRelease);
+
+        Log.Information("Release with name '{Name}' created", release.Name);
+        Log.Verbose("  Tag: {TagName}", release.TagName);
+        Log.Verbose("  Target commitish: {TargetCommitish}", release.TargetCommitish);
+        Log.Verbose("  Body: {Body}", release.Body);
+        Log.Verbose("  Draft: {Draft}", release.Draft);
+        Log.Verbose("  Pre-release: {PreRelease}", release.Prerelease);
+
+        if (settings.ArtifactPaths.Count > 0)
+        {
+            Log.Debug("Uploading {ArtifactCount} artifact(s) to release...", settings.ArtifactPaths.Count);
+
+            foreach (var artifactPath in settings.ArtifactPaths)
+            {
+                Log.Verbose("  Uploading artifact '{ArtifactPath}'...", artifactPath);
+
+                await using var assetFile = File.OpenRead(artifactPath);
+
+                var asset = new ReleaseAssetUpload
+                {
+                    FileName = Path.GetFileName(artifactPath),
+                    ContentType = "application/octet-stream",
+                    RawData = assetFile
+                };
+
+                var uploadedAsset = await client.Repository.Release.UploadAsset(release, asset);
+
+                Log.Information("  Artifact '{ArtifactName}' uploaded", uploadedAsset.Name);
+            }
+
+            Log.Debug("All artifacts uploaded");
+        }
+    }
+
+    /// <summary>
+    ///     Creates a new GitHub release using the GitHub API.
+    /// </summary>
+    /// <param name="configure">A method to use for configuring the settings of the release.</param>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    public static Task CreateRelease(Configure<GitHubReleaseSettings> configure)
+        => CreateRelease(configure(new GitHubReleaseSettings()));
+
+    /// <summary>
+    ///     Generates release notes for a specific tag using the GitHub API.
+    /// </summary>
+    /// <param name="settings">The settings to use for generating release notes.</param>
+    /// <returns>
+    ///     A <see cref="Task" /> representing the asynchronous operation. The task result contains the generated release
+    ///     name and content.
+    /// </returns>
+    public static async Task<(string Name, string Body)> GenerateReleaseNotes(GitHubReleaseNotesSettings settings)
+    {
+        settings.Validate();
+
+        var client = CreateGitHubClient(settings.Token!, settings.BaseUrl);
+
+        Log.Information("Generating release notes for tag '{TagName}'...", settings.Tag);
+
+        var releaseNotes = await client.Repository.Release.GenerateReleaseNotes(
+            settings.RepositoryOwner!,
+            settings.RepositoryName!,
+            new GenerateReleaseNotesRequest(settings.Tag)
+            {
+                TargetCommitish = settings.TargetCommitish,
+                PreviousTagName = settings.PreviousTag,
+                ConfigurationFilePath = settings.ConfigFile
+            });
+
+        Log.Debug("Release notes for tag '{TagName}' generated", settings.Tag);
+        Log.Verbose("  Name: {Name}", releaseNotes.Name);
+        Log.Verbose("  Body: {Body}", releaseNotes.Body);
+
+        return (releaseNotes.Name, releaseNotes.Body);
+    }
+
+    /// <summary>
+    ///     Generates release notes for a specific tag using the GitHub API.
+    /// </summary>
+    /// <param name="configure">A method to use for configuring the settings of the generation.</param>
+    /// <returns>
+    ///     A <see cref="Task" /> representing the asynchronous operation. The task result contains the generated release
+    ///     name and content.
+    /// </returns>
+    public static Task<(string Name, string Body)> GenerateReleaseNotes(Configure<GitHubReleaseNotesSettings> configure)
+        => GenerateReleaseNotes(configure(new GitHubReleaseNotesSettings()));
+
+    private static GitHubClient CreateGitHubClient(string token, string? baseAddress)
+    {
+        var productInformation = new ProductHeaderValue(Assembly.GetExecutingAssembly().GetName().Name);
+        var credentials = new Credentials(token);
+
+        return string.IsNullOrEmpty(baseAddress)
+            ? new GitHubClient(productInformation) { Credentials = credentials }
+            : new GitHubClient(productInformation, new Uri(baseAddress)) { Credentials = credentials };
+    }
+}

--- a/src/Ayaka.Nuke/GitHub/GitHubTasks.cs
+++ b/src/Ayaka.Nuke/GitHub/GitHubTasks.cs
@@ -24,11 +24,11 @@ public static class GitHubTasks
         var client = CreateGitHubClient(settings.Token!, settings.BaseUrl);
 
         Log.Debug("Checking whether release with tag '{TagName}' already exists...", settings.Tag);
-        
+
         var existingReleases = await client.Repository.Release.GetAll(
             settings.RepositoryOwner!,
             settings.RepositoryName!);
-        
+
         if (existingReleases.Any(x => x.TagName == settings.Tag))
         {
             Log.Warning("Release with tag '{TagName}' already exists. No GitHub release is created", settings.Tag);

--- a/src/Ayaka.Nuke/GitHub/ICanGitHubRelease.cs
+++ b/src/Ayaka.Nuke/GitHub/ICanGitHubRelease.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.GitHub;
+
+using global::Nuke.Common;
+using global::Nuke.Common.Tooling;
+using global::Nuke.Common.Tools.GitHub;
+
+/// <summary>
+///     Provides a target for creating a GitHub release to the <see cref="INukeBuild" />.
+/// </summary>
+public interface ICanGitHubRelease
+    : ICan,
+        IHaveGitRepository,
+        IHaveGitVersion,
+        IHaveGitHubToken,
+        IHaveGitHubReleaseTarget
+{
+    /// <summary>
+    ///     Gets the base settings for creating release notes.
+    /// </summary>
+    sealed Configure<GitHubReleaseNotesSettings> GitHubReleaseNotesSettingsBase
+        => notes => notes
+            .SetRepositoryOwner(GitRepository.GetGitHubOwner())
+            .SetRepositoryName(GitRepository.GetGitHubName())
+            .SetToken(GitHubToken!)
+            .SetTag($"v{Versioning.MajorMinorPatch}")
+            .SetTargetCommitish(Versioning.Sha);
+
+    /// <summary>
+    ///     Gets the additional settings for creating release notes.
+    /// </summary>
+    /// <remarks>
+    ///     Override this to provide additional settings for the <see cref="IHaveGitHubReleaseTarget.GitHubRelease" /> target.
+    /// </remarks>
+    Configure<GitHubReleaseNotesSettings> GitHubReleaseNotesSettings
+        => notes => notes;
+
+    /// <summary>
+    ///     Gets the base settings for creating a GitHub release.
+    /// </summary>
+    sealed Configure<GitHubReleaseSettings> GitHubReleaseSettingsBase
+        => release => release
+            .SetRepositoryOwner(GitRepository.GetGitHubOwner())
+            .SetRepositoryName(GitRepository.GetGitHubName())
+            .SetToken(GitHubToken!)
+            .SetTag($"v{Versioning.MajorMinorPatch}")
+            .SetTargetCommitish(Versioning.Sha)
+            .SetName($"v{Versioning.MajorMinorPatch}");
+
+    /// <summary>
+    ///     Gets the additional settings for creating a GitHub release.
+    /// </summary>
+    /// <remarks>
+    ///     Override this to provide additional settings for the <see cref="IHaveGitHubReleaseTarget.GitHubRelease" /> target.
+    /// </remarks>
+    Configure<GitHubReleaseSettings> GitHubReleaseSettings
+        => release => release;
+
+    /// <inheritdoc />
+    Target IHaveGitHubReleaseTarget.GitHubRelease => target => target
+        .Description("")
+        .Unlisted()
+        .Requires(() => GitHubToken)
+        .Executes(async () =>
+        {
+            var (_, body) = await GitHubTasks.GenerateReleaseNotes(
+                notes => notes
+                    .Apply(GitHubReleaseNotesSettingsBase)
+                    .Apply(GitHubReleaseNotesSettings));
+
+            await GitHubTasks.CreateRelease(
+                release => release
+                    .Apply(GitHubReleaseSettingsBase)
+                    .SetBody(body)
+                    .Apply(GitHubReleaseSettings));
+        });
+}

--- a/src/Ayaka.Nuke/GitHub/IHaveGitHubReleaseTarget.cs
+++ b/src/Ayaka.Nuke/GitHub/IHaveGitHubReleaseTarget.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.GitHub;
+
+using global::Nuke.Common;
+
+/// <summary>
+///     Indicates that a <see cref="INukeBuild" /> has a target for creating a GitHub release.
+/// </summary>
+public interface IHaveGitHubReleaseTarget
+    : IHave
+{
+    /// <summary>
+    ///     Gets the target for creating a GitHub release.
+    /// </summary>
+    Target GitHubRelease { get; }
+}

--- a/src/Ayaka.Nuke/GitHub/IHaveGitHubToken.cs
+++ b/src/Ayaka.Nuke/GitHub/IHaveGitHubToken.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.GitHub;
+
+using global::Nuke.Common;
+using global::Nuke.Common.CI.GitHubActions;
+
+/// <summary>
+///     Provides information about the GitHub credentials in a <see cref="INukeBuild" />.
+/// </summary>
+public interface IHaveGitHubToken
+    : IHave
+{
+    /// <summary>
+    ///     Gets the base URL for the GitHub API.
+    /// </summary>
+    /// <remarks>
+    /// </remarks>
+    [Parameter]
+    string? GitHubBaseUrl => TryGetValue(() => GitHubBaseUrl);
+
+    /// <summary>
+    ///     Gets the GitHub token used to authenticate with the GitHub API.
+    /// </summary>
+    [Parameter("The GitHub API token")]
+    [Secret]
+    string? GitHubToken => TryGetValue(() => GitHubToken)
+                           ?? GitHubActions.Instance?.Token;
+}

--- a/src/Ayaka.Nuke/PublicAPI.Unshipped.txt
+++ b/src/Ayaka.Nuke/PublicAPI.Unshipped.txt
@@ -50,6 +50,27 @@ Ayaka.Nuke.DotNetValidate.ICanDotNetValidate.NuGetPackagesToValidate.get -> Syst
 Ayaka.Nuke.DotNetValidate.IHaveDotNetValidateTarget
 Ayaka.Nuke.DotNetValidate.IHaveDotNetValidateTarget.DotNetValidate.get -> Nuke.Common.Target!
 Ayaka.Nuke.Extensions
+Ayaka.Nuke.GitHub.GitHubReleaseNotesSettings
+Ayaka.Nuke.GitHub.GitHubReleaseNotesSettings.GitHubReleaseNotesSettings() -> void
+Ayaka.Nuke.GitHub.GitHubReleaseNotesSettingsExtensions
+Ayaka.Nuke.GitHub.GitHubReleaseSettings
+Ayaka.Nuke.GitHub.GitHubReleaseSettings.GitHubReleaseSettings() -> void
+Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions
+Ayaka.Nuke.GitHub.GitHubSettings
+Ayaka.Nuke.GitHub.GitHubSettings.GitHubSettings() -> void
+Ayaka.Nuke.GitHub.GitHubSettings.Validate() -> void
+Ayaka.Nuke.GitHub.GitHubSettingsExtensions
+Ayaka.Nuke.GitHub.GitHubTasks
+Ayaka.Nuke.GitHub.ICanGitHubRelease
+Ayaka.Nuke.GitHub.ICanGitHubRelease.GitHubReleaseNotesSettings.get -> Nuke.Common.Tooling.Configure<Ayaka.Nuke.GitHub.GitHubReleaseNotesSettings!>!
+Ayaka.Nuke.GitHub.ICanGitHubRelease.GitHubReleaseNotesSettingsBase.get -> Nuke.Common.Tooling.Configure<Ayaka.Nuke.GitHub.GitHubReleaseNotesSettings!>!
+Ayaka.Nuke.GitHub.ICanGitHubRelease.GitHubReleaseSettings.get -> Nuke.Common.Tooling.Configure<Ayaka.Nuke.GitHub.GitHubReleaseSettings!>!
+Ayaka.Nuke.GitHub.ICanGitHubRelease.GitHubReleaseSettingsBase.get -> Nuke.Common.Tooling.Configure<Ayaka.Nuke.GitHub.GitHubReleaseSettings!>!
+Ayaka.Nuke.GitHub.IHaveGitHubReleaseTarget
+Ayaka.Nuke.GitHub.IHaveGitHubReleaseTarget.GitHubRelease.get -> Nuke.Common.Target!
+Ayaka.Nuke.GitHub.IHaveGitHubToken
+Ayaka.Nuke.GitHub.IHaveGitHubToken.GitHubBaseUrl.get -> string?
+Ayaka.Nuke.GitHub.IHaveGitHubToken.GitHubToken.get -> string?
 Ayaka.Nuke.ICan
 Ayaka.Nuke.ICanClean
 Ayaka.Nuke.IHave
@@ -86,6 +107,8 @@ override Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.Configure
 override Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.ProcessExitHandler.get -> System.Action<Nuke.Common.Tooling.ToolSettings!, Nuke.Common.Tooling.IProcess!>!
 override Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.ProcessLogger.get -> System.Action<Nuke.Common.Tooling.OutputType, string!>!
 override Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.ProcessToolPath.get -> string!
+override Ayaka.Nuke.GitHub.GitHubReleaseNotesSettings.AssertValid() -> void
+override Ayaka.Nuke.GitHub.GitHubReleaseSettings.AssertValid() -> void
 static Ayaka.Nuke.DotNet.Configuration.Debug -> Ayaka.Nuke.DotNet.Configuration!
 static Ayaka.Nuke.DotNet.Configuration.implicit operator string!(Ayaka.Nuke.DotNet.Configuration! configuration) -> string!
 static Ayaka.Nuke.DotNet.Configuration.Release -> Ayaka.Nuke.DotNet.Configuration!
@@ -110,7 +133,60 @@ static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidateRemotePackage
 static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidateRemotePackage(Nuke.Common.Tooling.CombinatorialConfigure<Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings!>! configurator, int degreeOfParallelism = 1, bool completeOnFailure = false) -> System.Collections.Generic.IEnumerable<(Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings! Settings, System.Collections.Generic.IReadOnlyCollection<Nuke.Common.Tooling.Output>! Output)>!
 static Ayaka.Nuke.DotNetValidate.DotNetValidateTasks.DotNetValidateRemotePackage(Nuke.Common.Tooling.Configure<Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings!>! configurator) -> System.Collections.Generic.IReadOnlyCollection<Nuke.Common.Tooling.Output>!
 static Ayaka.Nuke.Extensions.WhenNotNull<T, TObject>(this T settings, TObject? obj, System.Func<T, TObject, T>! configurator) -> T
+static Ayaka.Nuke.GitHub.GitHubReleaseNotesSettingsExtensions.ResetConfigFile<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseNotesSettingsExtensions.ResetPreviousTag<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseNotesSettingsExtensions.ResetTag<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseNotesSettingsExtensions.ResetTargetCommitish<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseNotesSettingsExtensions.SetConfigFile<T>(this T! settings, string! configFile) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseNotesSettingsExtensions.SetPreviousTag<T>(this T! settings, string! previousTag) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseNotesSettingsExtensions.SetTag<T>(this T! settings, string! tagName) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseNotesSettingsExtensions.SetTargetCommitish<T>(this T! settings, string! targetCommitish) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.AddArtifactPath<T>(this T! settings, string! artifactPath) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.ClearArtifactPaths<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.ResetBody<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.ResetDraft<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.ResetGenerateReleaseNotes<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.ResetName<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.ResetPreRelease<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.ResetTag<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.ResetTargetCommitish<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.SetBody<T>(this T! settings, string! body) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.SetDraft<T>(this T! settings, bool draft) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.SetGenerateReleaseNotes<T>(this T! settings, bool generateReleaseNotes) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.SetName<T>(this T! settings, string! name) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.SetPreRelease<T>(this T! settings, bool preRelease) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.SetTag<T>(this T! settings, string! tagName) -> T!
+static Ayaka.Nuke.GitHub.GitHubReleaseSettingsExtensions.SetTargetCommitish<T>(this T! settings, string! targetCommitish) -> T!
+static Ayaka.Nuke.GitHub.GitHubSettingsExtensions.ResetBaseUrl<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubSettingsExtensions.ResetRepositoryName<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubSettingsExtensions.ResetRepositoryOwner<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubSettingsExtensions.ResetToken<T>(this T! settings) -> T!
+static Ayaka.Nuke.GitHub.GitHubSettingsExtensions.SetBaseUrl<T>(this T! settings, string! baseUrl) -> T!
+static Ayaka.Nuke.GitHub.GitHubSettingsExtensions.SetRepositoryName<T>(this T! settings, string! repositoryName) -> T!
+static Ayaka.Nuke.GitHub.GitHubSettingsExtensions.SetRepositoryOwner<T>(this T! settings, string! repositoryOwner) -> T!
+static Ayaka.Nuke.GitHub.GitHubSettingsExtensions.SetToken<T>(this T! settings, string! token) -> T!
+static Ayaka.Nuke.GitHub.GitHubTasks.CreateRelease(Ayaka.Nuke.GitHub.GitHubReleaseSettings! settings) -> System.Threading.Tasks.Task!
+static Ayaka.Nuke.GitHub.GitHubTasks.CreateRelease(Nuke.Common.Tooling.Configure<Ayaka.Nuke.GitHub.GitHubReleaseSettings!>! configure) -> System.Threading.Tasks.Task!
+static Ayaka.Nuke.GitHub.GitHubTasks.GenerateReleaseNotes(Ayaka.Nuke.GitHub.GitHubReleaseNotesSettings! settings) -> System.Threading.Tasks.Task<(string! Name, string! Body)>!
+static Ayaka.Nuke.GitHub.GitHubTasks.GenerateReleaseNotes(Nuke.Common.Tooling.Configure<Ayaka.Nuke.GitHub.GitHubReleaseNotesSettings!>! configure) -> System.Threading.Tasks.Task<(string! Name, string! Body)>!
 virtual Ayaka.Nuke.DotNetValidate.DotNetValidateLocalPackageSettings.PackagePath.get -> string?
 virtual Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.ConfigDirectory.get -> string?
 virtual Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.PackageId.get -> string?
 virtual Ayaka.Nuke.DotNetValidate.DotNetValidateRemotePackageSettings.PackageVersion.get -> string?
+virtual Ayaka.Nuke.GitHub.GitHubReleaseNotesSettings.ConfigFile.get -> string?
+virtual Ayaka.Nuke.GitHub.GitHubReleaseNotesSettings.PreviousTag.get -> string?
+virtual Ayaka.Nuke.GitHub.GitHubReleaseNotesSettings.Tag.get -> string?
+virtual Ayaka.Nuke.GitHub.GitHubReleaseNotesSettings.TargetCommitish.get -> string?
+virtual Ayaka.Nuke.GitHub.GitHubReleaseSettings.ArtifactPaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
+virtual Ayaka.Nuke.GitHub.GitHubReleaseSettings.Body.get -> string?
+virtual Ayaka.Nuke.GitHub.GitHubReleaseSettings.Draft.get -> bool?
+virtual Ayaka.Nuke.GitHub.GitHubReleaseSettings.GenerateReleaseNotes.get -> bool?
+virtual Ayaka.Nuke.GitHub.GitHubReleaseSettings.Name.get -> string?
+virtual Ayaka.Nuke.GitHub.GitHubReleaseSettings.PreRelease.get -> bool?
+virtual Ayaka.Nuke.GitHub.GitHubReleaseSettings.Tag.get -> string?
+virtual Ayaka.Nuke.GitHub.GitHubReleaseSettings.TargetCommitish.get -> string?
+virtual Ayaka.Nuke.GitHub.GitHubSettings.AssertValid() -> void
+virtual Ayaka.Nuke.GitHub.GitHubSettings.BaseUrl.get -> string?
+virtual Ayaka.Nuke.GitHub.GitHubSettings.RepositoryName.get -> string?
+virtual Ayaka.Nuke.GitHub.GitHubSettings.RepositoryOwner.get -> string?
+virtual Ayaka.Nuke.GitHub.GitHubSettings.Token.get -> string?

--- a/test/Ayaka.Nuke.Tests/GitHub/GitHubReleaseNotesSettingsExtensionsTest.cs
+++ b/test/Ayaka.Nuke.Tests/GitHub/GitHubReleaseNotesSettingsExtensionsTest.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.Tests.GitHub;
+
+using Ayaka.Nuke.GitHub;
+using Light.GuardClauses.Exceptions;
+
+public sealed class GitHubReleaseNotesSettingsExtensionsTest
+{
+    [Fact]
+    public void Does_set_Tag()
+    {
+        var original = new GitHubReleaseNotesSettings();
+
+        var actual = original.SetTag("v1.0");
+
+        actual.Should().NotBeSameAs(original);
+        original.Tag.Should().Be(expected: null);
+        actual.Tag.Should().Be("v1.0");
+    }
+
+    [Fact]
+    public void Does_reset_Tag()
+    {
+        var original = new GitHubReleaseNotesSettings()
+            .SetTag("v1.0");
+
+        var actual = original.ResetTag();
+
+        actual.Should().NotBeSameAs(original);
+        original.Tag.Should().Be("v1.0");
+        actual.Tag.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_set_TargetCommitish()
+    {
+        var original = new GitHubReleaseNotesSettings();
+
+        var actual = original.SetTargetCommitish("main");
+
+        actual.Should().NotBeSameAs(original);
+        original.TargetCommitish.Should().Be(expected: null);
+        actual.TargetCommitish.Should().Be("main");
+    }
+
+    [Fact]
+    public void Does_reset_TargetCommitish()
+    {
+        var original = new GitHubReleaseNotesSettings()
+            .SetTargetCommitish("main");
+
+        var actual = original.ResetTargetCommitish();
+
+        actual.Should().NotBeSameAs(original);
+        original.TargetCommitish.Should().Be("main");
+        actual.TargetCommitish.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_set_PreviousTag()
+    {
+        var original = new GitHubReleaseNotesSettings();
+
+        var actual = original.SetPreviousTag("v0.9");
+
+        actual.Should().NotBeSameAs(original);
+        original.PreviousTag.Should().Be(expected: null);
+        actual.PreviousTag.Should().Be("v0.9");
+    }
+
+    [Fact]
+    public void Does_reset_PreviousTag()
+    {
+        var original = new GitHubReleaseNotesSettings()
+            .SetPreviousTag("v0.9");
+
+        var actual = original.ResetPreviousTag();
+
+        actual.Should().NotBeSameAs(original);
+        original.PreviousTag.Should().Be("v0.9");
+        actual.PreviousTag.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_set_ConfigFile()
+    {
+        var original = new GitHubReleaseNotesSettings();
+
+        var actual = original.SetConfigFile("release.yml");
+
+        actual.Should().NotBeSameAs(original);
+        original.ConfigFile.Should().Be(expected: null);
+        actual.ConfigFile.Should().Be("release.yml");
+    }
+
+    [Fact]
+    public void Does_reset_ConfigFile()
+    {
+        var original = new GitHubReleaseNotesSettings()
+            .SetConfigFile("release.yml");
+
+        var actual = original.ResetConfigFile();
+
+        actual.Should().NotBeSameAs(original);
+        original.ConfigFile.Should().Be("release.yml");
+        actual.ConfigFile.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_validate_settings_Tag_null()
+    {
+        var settings = new GitHubReleaseNotesSettings()
+            .SetRepositoryOwner("owner")
+            .SetRepositoryName("name")
+            .SetToken("token")
+            .SetTag(null!);
+
+        var action = () => settings.Validate();
+
+        action
+            .Should()
+            .Throw<ArgumentNullException>()
+            .WithParameterName(nameof(GitHubReleaseNotesSettings.Tag));
+    }
+
+    [Fact]
+    public void Does_validate_settings_Tag_empty()
+    {
+        var settings = new GitHubReleaseNotesSettings()
+            .SetRepositoryOwner("owner")
+            .SetRepositoryName("name")
+            .SetToken("token")
+            .SetTag("");
+
+        var action = () => settings.Validate();
+
+        action
+            .Should()
+            .Throw<EmptyStringException>()
+            .WithParameterName(nameof(GitHubReleaseNotesSettings.Tag));
+    }
+}

--- a/test/Ayaka.Nuke.Tests/GitHub/GitHubReleaseSettingsExtensionsTest.cs
+++ b/test/Ayaka.Nuke.Tests/GitHub/GitHubReleaseSettingsExtensionsTest.cs
@@ -1,0 +1,317 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.Tests.GitHub;
+
+using Ayaka.Nuke.GitHub;
+using Light.GuardClauses.Exceptions;
+
+public sealed class GitHubReleaseSettingsExtensionsTest
+{
+    [Fact]
+    public void Does_set_Tag()
+    {
+        var original = new GitHubReleaseSettings();
+
+        var actual = original.SetTag("v1.0");
+
+        actual.Should().NotBeSameAs(original);
+        original.Tag.Should().Be(expected: null);
+        actual.Tag.Should().Be("v1.0");
+    }
+
+    [Fact]
+    public void Does_reset_Tag()
+    {
+        var original = new GitHubReleaseSettings()
+            .SetTag("v1.0");
+
+        var actual = original.ResetTag();
+
+        actual.Should().NotBeSameAs(original);
+        original.Tag.Should().Be("v1.0");
+        actual.Tag.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_set_TargetCommitish()
+    {
+        var original = new GitHubReleaseSettings();
+
+        var actual = original.SetTargetCommitish("main");
+
+        actual.Should().NotBeSameAs(original);
+        original.TargetCommitish.Should().Be(expected: null);
+        actual.TargetCommitish.Should().Be("main");
+    }
+
+    [Fact]
+    public void Does_reset_TargetCommitish()
+    {
+        var original = new GitHubReleaseSettings()
+            .SetTargetCommitish("main");
+
+        var actual = original.ResetTargetCommitish();
+
+        actual.Should().NotBeSameAs(original);
+        original.TargetCommitish.Should().Be("main");
+        actual.TargetCommitish.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_set_Name()
+    {
+        var original = new GitHubReleaseSettings();
+
+        var actual = original.SetName("Release v1.0");
+
+        actual.Should().NotBeSameAs(original);
+        original.Name.Should().Be(expected: null);
+        actual.Name.Should().Be("Release v1.0");
+    }
+
+    [Fact]
+    public void Does_reset_Name()
+    {
+        var original = new GitHubReleaseSettings()
+            .SetName("Release v1.0");
+
+        var actual = original.ResetName();
+
+        actual.Should().NotBeSameAs(original);
+        original.Name.Should().Be("Release v1.0");
+        actual.Name.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_set_Body()
+    {
+        var original = new GitHubReleaseSettings();
+
+        var actual = original.SetBody("This is the release notes for v1.0.");
+
+        actual.Should().NotBeSameAs(original);
+        original.Body.Should().Be(expected: null);
+        actual.Body.Should().Be("This is the release notes for v1.0.");
+    }
+
+    [Fact]
+    public void Does_reset_Body()
+    {
+        var original = new GitHubReleaseSettings()
+            .SetBody("This is the release notes for v1.0.");
+
+        var actual = original.ResetBody();
+
+        actual.Should().NotBeSameAs(original);
+        original.Body.Should().Be("This is the release notes for v1.0.");
+        actual.Body.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_set_Draft()
+    {
+        var original = new GitHubReleaseSettings();
+
+        var actual = original.SetDraft(draft: true);
+
+        actual.Should().NotBeSameAs(original);
+        original.Draft.Should().Be(expected: null);
+        actual.Draft.Should().Be(expected: true);
+    }
+
+    [Fact]
+    public void Does_reset_Draft()
+    {
+        var original = new GitHubReleaseSettings()
+            .SetDraft(draft: true);
+
+        var actual = original.ResetDraft();
+
+        actual.Should().NotBeSameAs(original);
+        original.Draft.Should().Be(expected: true);
+        actual.Draft.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_set_PreRelease()
+    {
+        var original = new GitHubReleaseSettings();
+
+        var actual = original.SetPreRelease(preRelease: true);
+
+        actual.Should().NotBeSameAs(original);
+        original.PreRelease.Should().Be(expected: null);
+        actual.PreRelease.Should().Be(expected: true);
+    }
+
+    [Fact]
+    public void Does_reset_PreRelease()
+    {
+        var original = new GitHubReleaseSettings()
+            .SetPreRelease(preRelease: true);
+
+        var actual = original.ResetPreRelease();
+
+        actual.Should().NotBeSameAs(original);
+        original.PreRelease.Should().Be(expected: true);
+        actual.PreRelease.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_set_GenerateReleaseNotes()
+    {
+        var original = new GitHubReleaseSettings();
+
+        var actual = original.SetGenerateReleaseNotes(generateReleaseNotes: true);
+
+        actual.Should().NotBeSameAs(original);
+        original.GenerateReleaseNotes.Should().Be(expected: null);
+        actual.GenerateReleaseNotes.Should().Be(expected: true);
+    }
+
+    [Fact]
+    public void Does_reset_GenerateReleaseNotes()
+    {
+        var original = new GitHubReleaseSettings()
+            .SetGenerateReleaseNotes(generateReleaseNotes: true);
+
+        var actual = original.ResetGenerateReleaseNotes();
+
+        actual.Should().NotBeSameAs(original);
+        original.GenerateReleaseNotes.Should().Be(expected: true);
+        actual.GenerateReleaseNotes.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_add_ArtifactPath()
+    {
+        var original = new GitHubReleaseSettings();
+
+        var actual = original.AddArtifactPath("path/to/artifact");
+
+        actual.Should().NotBeSameAs(original);
+        original.ArtifactPaths.Should().BeEmpty();
+        actual.ArtifactPaths.Should().ContainSingle().Which.Should().Be("path/to/artifact");
+    }
+
+    [Fact]
+    public void Does_clear_ArtifactPath()
+    {
+        var original = new GitHubReleaseSettings()
+            .AddArtifactPath("path/to/artifact");
+
+        var actual = original.ClearArtifactPaths();
+
+        actual.Should().NotBeSameAs(original);
+        original.ArtifactPaths.Should().ContainSingle().Which.Should().Be("path/to/artifact");
+        actual.ArtifactPaths.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Does_validate_settings_Tag_null()
+    {
+        var settings = new GitHubReleaseSettings()
+            .SetRepositoryOwner("owner")
+            .SetRepositoryName("name")
+            .SetToken("token")
+            .SetTag(null!);
+
+        var action = () => settings.Validate();
+
+        action
+            .Should()
+            .Throw<ArgumentNullException>()
+            .WithParameterName(nameof(GitHubReleaseSettings.Tag));
+    }
+
+    [Fact]
+    public void Does_validate_settings_Tag_empty()
+    {
+        var settings = new GitHubReleaseSettings()
+            .SetRepositoryOwner("owner")
+            .SetRepositoryName("name")
+            .SetToken("token")
+            .SetTag("");
+
+        var action = () => settings.Validate();
+
+        action
+            .Should()
+            .Throw<EmptyStringException>()
+            .WithParameterName(nameof(GitHubReleaseSettings.Tag));
+    }
+
+    [Fact]
+    public void Does_validate_settings_Name_null()
+    {
+        var settings = new GitHubReleaseSettings()
+            .SetRepositoryOwner("owner")
+            .SetRepositoryName("name")
+            .SetToken("token")
+            .SetTag("v1.0")
+            .SetName(null!);
+
+        var action = () => settings.Validate();
+
+        action
+            .Should()
+            .Throw<ArgumentNullException>()
+            .WithParameterName(nameof(GitHubReleaseSettings.Name));
+    }
+
+    [Fact]
+    public void Does_validate_settings_Name_empty()
+    {
+        var settings = new GitHubReleaseSettings()
+            .SetRepositoryOwner("owner")
+            .SetRepositoryName("name")
+            .SetToken("token")
+            .SetTag("v1.0")
+            .SetName("");
+
+        var action = () => settings.Validate();
+
+        action
+            .Should()
+            .Throw<EmptyStringException>()
+            .WithParameterName(nameof(GitHubReleaseSettings.Name));
+    }
+
+    [Fact]
+    public void Does_validate_settings_Body_null()
+    {
+        var settings = new GitHubReleaseSettings()
+            .SetRepositoryOwner("owner")
+            .SetRepositoryName("name")
+            .SetToken("token")
+            .SetTag("v1.0")
+            .SetName("Release v1.0")
+            .SetBody(null!);
+
+        var action = () => settings.Validate();
+
+        action
+            .Should()
+            .Throw<ArgumentNullException>()
+            .WithParameterName(nameof(GitHubReleaseSettings.Body));
+    }
+
+    [Fact]
+    public void Does_validate_settings_Body_empty()
+    {
+        var settings = new GitHubReleaseSettings()
+            .SetRepositoryOwner("owner")
+            .SetRepositoryName("name")
+            .SetToken("token")
+            .SetTag("v1.0")
+            .SetName("Release v1.0")
+            .SetBody("");
+
+        var action = () => settings.Validate();
+
+        action
+            .Should()
+            .Throw<EmptyStringException>()
+            .WithParameterName(nameof(GitHubReleaseSettings.Body));
+    }
+}

--- a/test/Ayaka.Nuke.Tests/GitHub/GitHubSettingsTest.cs
+++ b/test/Ayaka.Nuke.Tests/GitHub/GitHubSettingsTest.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.Tests.GitHub;
+
+using Ayaka.Nuke.GitHub;
+using Light.GuardClauses.Exceptions;
+
+public sealed class GitHubSettingsExtensionsTest
+{
+    [Fact]
+    public void Does_set_RepositoryOwner()
+    {
+        var original = new GitHubSettings();
+
+        var actual = original.SetRepositoryOwner("owner");
+
+        actual.Should().NotBeSameAs(original);
+        original.RepositoryOwner.Should().Be(expected: null);
+        actual.RepositoryOwner.Should().Be("owner");
+    }
+
+    [Fact]
+    public void Does_reset_RepositoryOwner()
+    {
+        var original = new GitHubSettings()
+            .SetRepositoryOwner("owner");
+
+        var actual = original.ResetRepositoryOwner();
+
+        actual.Should().NotBeSameAs(original);
+        original.RepositoryOwner.Should().Be("owner");
+        actual.RepositoryOwner.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_set_RepositoryName()
+    {
+        var original = new GitHubSettings();
+
+        var actual = original.SetRepositoryName("name");
+
+        actual.Should().NotBeSameAs(original);
+        original.RepositoryName.Should().Be(expected: null);
+        actual.RepositoryName.Should().Be("name");
+    }
+
+    [Fact]
+    public void Does_reset_RepositoryName()
+    {
+        var original = new GitHubSettings()
+            .SetRepositoryName("name");
+
+        var actual = original.ResetRepositoryName();
+
+        actual.Should().NotBeSameAs(original);
+        original.RepositoryName.Should().Be("name");
+        actual.RepositoryName.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_set_Token()
+    {
+        var original = new GitHubSettings();
+
+        var actual = original.SetToken("token");
+
+        actual.Should().NotBeSameAs(original);
+        original.Token.Should().Be(expected: null);
+        actual.Token.Should().Be("token");
+    }
+
+    [Fact]
+    public void Does_reset_Token()
+    {
+        var original = new GitHubSettings()
+            .SetToken("token");
+
+        var actual = original.ResetToken();
+
+        actual.Should().NotBeSameAs(original);
+        original.Token.Should().Be("token");
+        actual.Token.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_set_BaseUrl()
+    {
+        var original = new GitHubSettings();
+
+        var actual = original.SetBaseUrl("url");
+
+        actual.Should().NotBeSameAs(original);
+        original.BaseUrl.Should().Be(expected: null);
+        actual.BaseUrl.Should().Be("url");
+    }
+
+    [Fact]
+    public void Does_reset_BaseUrl()
+    {
+        var original = new GitHubSettings()
+            .SetBaseUrl("url");
+
+        var actual = original.ResetBaseUrl();
+
+        actual.Should().NotBeSameAs(original);
+        original.BaseUrl.Should().Be("url");
+        actual.BaseUrl.Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void Does_validate_settings_RepositoryOwner_null()
+    {
+        var settings = new GitHubSettings()
+            .SetRepositoryOwner(null!);
+
+        var action = () => settings.Validate();
+
+        action
+            .Should()
+            .Throw<ArgumentNullException>()
+            .WithParameterName(nameof(GitHubSettings.RepositoryOwner));
+    }
+
+    [Fact]
+    public void Does_validate_settings_RepositoryOwner_empty()
+    {
+        var settings = new GitHubSettings()
+            .SetRepositoryOwner("");
+
+        var action = () => settings.Validate();
+
+        action
+            .Should()
+            .Throw<EmptyStringException>()
+            .WithParameterName(nameof(GitHubSettings.RepositoryOwner));
+    }
+
+    [Fact]
+    public void Does_validate_settings_RepositoryName_null()
+    {
+        var settings = new GitHubSettings()
+            .SetRepositoryOwner("owner")
+            .SetRepositoryName(null!);
+
+        var action = () => settings.Validate();
+
+        action
+            .Should()
+            .Throw<ArgumentNullException>()
+            .WithParameterName(nameof(GitHubSettings.RepositoryName));
+    }
+
+    [Fact]
+    public void Does_validate_settings_RepositoryName_empty()
+    {
+        var settings = new GitHubSettings()
+            .SetRepositoryOwner("owner")
+            .SetRepositoryName("");
+
+        var action = () => settings.Validate();
+
+        action
+            .Should()
+            .Throw<EmptyStringException>()
+            .WithParameterName(nameof(GitHubSettings.RepositoryName));
+    }
+
+    [Fact]
+    public void Does_validate_settings_Token_null()
+    {
+        var settings = new GitHubSettings()
+            .SetRepositoryOwner("owner")
+            .SetRepositoryName("name")
+            .SetToken(null!);
+
+        var action = () => settings.Validate();
+
+        action
+            .Should()
+            .Throw<ArgumentNullException>()
+            .WithParameterName(nameof(GitHubSettings.Token));
+    }
+
+    [Fact]
+    public void Does_validate_settings_Token_empty()
+    {
+        var settings = new GitHubSettings()
+            .SetRepositoryOwner("owner")
+            .SetRepositoryName("name")
+            .SetToken("");
+
+        var action = () => settings.Validate();
+
+        action
+            .Should()
+            .Throw<EmptyStringException>()
+            .WithParameterName(nameof(GitHubSettings.Token));
+    }
+}


### PR DESCRIPTION
## Description

Adds support to create GitHub releases using the GitHub API.
Adds a new workflow that creates a new release based on the main branch.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Manual testing and some unit tests that cover the tool settings classes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
