### PR TITLE
chore: disable code coverage on NUKE build stuff

### DIFF
--- a/build/Usings.props
+++ b/build/Usings.props
@@ -4,6 +4,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
+  </ItemGroup>
+
   <!-- Global Usings for test projects -->
   <ItemGroup Condition="'$(IsTestProject)' == 'True'">
     <Using Include="FakeItEasy" />

--- a/src/Ayaka.Nuke/DotNet/ICanDotNetBuild.cs
+++ b/src/Ayaka.Nuke/DotNet/ICanDotNetBuild.cs
@@ -23,6 +23,7 @@ public interface ICanDotNetBuild
     /// <remarks>
     ///     Applies versioning information if <see cref="IHaveGitVersion" /> is implemented.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     sealed Configure<DotNetBuildSettings> DotNetBuildSettingsBase
         => dotnet => dotnet
             .SetProjectFile(Solution)
@@ -42,10 +43,12 @@ public interface ICanDotNetBuild
     /// <remarks>
     ///     Override this to provide additional settings for the <see cref="IHaveDotNetBuildTarget.DotNetBuild" /> target.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     Configure<DotNetBuildSettings> DotNetBuildSettings
         => dotnet => dotnet;
 
     /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
     Target IHaveDotNetBuildTarget.DotNetBuild => target => target
         .Description("Compiles the current solution using .NET CLI")
         .Unlisted()

--- a/src/Ayaka.Nuke/DotNet/ICanDotNetPack.cs
+++ b/src/Ayaka.Nuke/DotNet/ICanDotNetPack.cs
@@ -22,6 +22,7 @@ public interface ICanDotNetPack
     /// <summary>
     ///     Gets the base settings for packing the current solution.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     sealed Configure<DotNetPackSettings> DotNetPackSettingsBase
         => dotnet => dotnet
             .SetProject(Solution)
@@ -41,10 +42,12 @@ public interface ICanDotNetPack
     /// <remarks>
     ///     Override this to provide additional settings for the <see cref="IHaveDotNetPackTarget.DotNetPack" />.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     Configure<DotNetPackSettings> DotNetPackSettings
         => dotnet => dotnet;
 
     /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
     Target IHaveDotNetPackTarget.DotNetPack => target => target
         .Description("Packs the current solution using .NET CLI")
         .Unlisted()

--- a/src/Ayaka.Nuke/DotNet/ICanDotNetPush.cs
+++ b/src/Ayaka.Nuke/DotNet/ICanDotNetPush.cs
@@ -21,6 +21,7 @@ public interface ICanDotNetPush
     /// <summary>
     ///     Gets the base settings for pushing NuGet packages.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     sealed Configure<DotNetNuGetPushSettings> DotNetPushSettingsBase
         => dotnet => dotnet
             .SetSource(NuGetSource)
@@ -33,12 +34,14 @@ public interface ICanDotNetPush
     /// <remarks>
     ///     Override this to provide additional settings for the <see cref="IHaveDotNetPushTarget.DotNetPush" /> target.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     Configure<DotNetNuGetPushSettings> DotNetPushSettings
         => dotnet => dotnet;
 
     /// <summary>
     ///     Gets the base settings for pushing a specific NuGet package.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     sealed Configure<DotNetNuGetPushSettings, AbsolutePath> DotNetPushPackageSettingsBase
         => (dotnet, packagePath) => dotnet
             .SetTargetPath(packagePath);
@@ -49,6 +52,7 @@ public interface ICanDotNetPush
     /// <remarks>
     ///     Override this to provide additional settings for the <see cref="IHaveDotNetPushTarget.DotNetPush" /> target.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     Configure<DotNetNuGetPushSettings, AbsolutePath> DotNetPushPackageSettings
         => (dotnet, packagePath) => dotnet;
 
@@ -62,9 +66,11 @@ public interface ICanDotNetPush
     ///         Please note that symbols packages present in the package directory are pushed automatically.
     ///     </para>
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     IEnumerable<AbsolutePath> NuGetPackagesToPush => PackagesDirectory.GlobFiles("*.nupkg");
 
     /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
     Target IHaveDotNetPushTarget.DotNetPush => target => target
         .Description("Pushes all NuGet packages using .NET CLI")
         .Unlisted()

--- a/src/Ayaka.Nuke/DotNet/ICanDotNetRestore.cs
+++ b/src/Ayaka.Nuke/DotNet/ICanDotNetRestore.cs
@@ -17,6 +17,7 @@ public interface ICanDotNetRestore
     /// <summary>
     ///     Gets the base settings for restoring the current solution.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     sealed Configure<DotNetRestoreSettings> DotNetRestoreSettingsBase
         => dotnet => dotnet
             .SetProjectFile(Solution);
@@ -27,10 +28,12 @@ public interface ICanDotNetRestore
     /// <remarks>
     ///     Override this to provide additional settings for the <see cref="IHaveDotNetRestoreTarget.DotNetRestore" /> target.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     Configure<DotNetRestoreSettings> DotNetRestoreSettings
         => dotnet => dotnet;
 
     /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
     Target IHaveDotNetRestoreTarget.DotNetRestore => target => target
         .Description("Restores the current solution using .NET CLI")
         .Unlisted()

--- a/src/Ayaka.Nuke/DotNet/ICanDotNetTest.cs
+++ b/src/Ayaka.Nuke/DotNet/ICanDotNetTest.cs
@@ -30,6 +30,7 @@ public interface ICanDotNetTest
     /// <summary>
     ///     Gets the base settings for testing a project.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     sealed Configure<DotNetTestSettings> DotNetTestSettingsBase
         => dotnet => dotnet
             .SetConfiguration(DotNetConfiguration)
@@ -43,12 +44,14 @@ public interface ICanDotNetTest
     /// <remarks>
     ///     Override this to provide additional settings for the <see cref="IHaveDotNetTestTarget.DotNetTest" /> target.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     Configure<DotNetTestSettings> DotNetTestSettings
         => dotnet => dotnet;
 
     /// <summary>
     ///     Gets the base settings for testing a project scoped to one specific project.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     sealed Configure<DotNetTestSettings, Project> DotNetTestProjectSettingsBase
         => (dotnet, project) => dotnet
             .SetProjectFile(project)
@@ -68,6 +71,7 @@ public interface ICanDotNetTest
     /// <remarks>
     ///     Override this to provide additional settings for the <see cref="IHaveDotNetTestTarget.DotNetTest" /> target.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     Configure<DotNetTestSettings, Project> DotNetTestProjectSettings
         => (dotnet, project) => dotnet;
 
@@ -77,12 +81,14 @@ public interface ICanDotNetTest
     /// <remarks>
     ///     If not overridden, all projects in the <see cref="IHaveTests.TestsDirectory" /> are considered test projects.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     IEnumerable<Project> TestProjects
         => Solution
             .AllProjects
             .Where(x => TestsDirectory.Contains(x.Path));
 
     /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
     Target IHaveDotNetTestTarget.DotNetTest => target => target
         .Description("Tests all test projects using .NET CLI")
         .Unlisted()
@@ -129,6 +135,7 @@ public interface ICanDotNetTest
     ///         Use <c>.AddLoggers($"trx;LogFileName={project.Name}.trx")</c> on the per-project test settings to enable this.
     ///     </para>
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     void ReportTestCount()
     {
         static IEnumerable<string> GetOutcomes(AbsolutePath file)

--- a/src/Ayaka.Nuke/DotNet/IHaveDotNetConfiguration.cs
+++ b/src/Ayaka.Nuke/DotNet/IHaveDotNetConfiguration.cs
@@ -17,6 +17,7 @@ public interface IHaveDotNetConfiguration : IHave
     ///     <see cref="Configuration.Release" />.
     /// </remarks>
     [Parameter("The .NET build configuration - Default is 'Debug' (local) or 'Release' (server)")]
+    [ExcludeFromCodeCoverage]
     Configuration DotNetConfiguration => TryGetValue(() => DotNetConfiguration)
                                          ?? (IsLocalBuild ? Configuration.Debug : Configuration.Release);
 }

--- a/src/Ayaka.Nuke/DotNet/TargetDefinitionExtensions.cs
+++ b/src/Ayaka.Nuke/DotNet/TargetDefinitionExtensions.cs
@@ -6,6 +6,7 @@ using global::Nuke.Common;
 using global::Nuke.Common.IO;
 using static global::Nuke.Common.IO.FileSystemTasks;
 
+[ExcludeFromCodeCoverage]
 internal static class TargetDefinitionExtensions
 {
     /// <summary>

--- a/src/Ayaka.Nuke/DotNetValidate/DotNetValidateTasks.cs
+++ b/src/Ayaka.Nuke/DotNetValidate/DotNetValidateTasks.cs
@@ -8,6 +8,7 @@ using global::Nuke.Common.Tooling;
 ///     Provides tasks for validating NuGet packages using <c>dotnet-validate</c> CLI tool.
 /// </summary>
 [NuGetPackageRequirement(DotNetValidatePackageId)]
+[ExcludeFromCodeCoverage]
 public class DotNetValidateTasks
     : IRequireNuGetPackage
 {

--- a/src/Ayaka.Nuke/DotNetValidate/ICanDotNetValidate.cs
+++ b/src/Ayaka.Nuke/DotNetValidate/ICanDotNetValidate.cs
@@ -18,6 +18,7 @@ public interface ICanDotNetValidate
     /// <summary>
     ///     Gets the base settings for validating a specific NuGet package.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     sealed Configure<DotNetValidateLocalPackageSettings, AbsolutePath> DotNetValidatePackageSettingsBase
         => (dotnetValidate, packagePath) => dotnetValidate
             .SetPackagePath(packagePath);
@@ -29,6 +30,7 @@ public interface ICanDotNetValidate
     ///     Override this to provide additional settings for the <see cref="IHaveDotNetValidateTarget.DotNetValidate" />
     ///     target.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     Configure<DotNetValidateLocalPackageSettings, AbsolutePath> DotNetValidatePackageSettings
         => (dotnetValidate, packagePath) => dotnetValidate;
 
@@ -39,9 +41,11 @@ public interface ICanDotNetValidate
     ///     If not overridden, all <c>*.nupkg</c> files in the <see cref="IHavePackageArtifacts.PackagesDirectory" /> are
     ///     considered packages.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     IEnumerable<AbsolutePath> NuGetPackagesToValidate => PackagesDirectory.GlobFiles("*.nupkg");
 
     /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
     Target IHaveDotNetValidateTarget.DotNetValidate => target => target
         .Description("Validates all NuGet packages using 'dotnet-validate' CLI tool")
         .Unlisted()

--- a/src/Ayaka.Nuke/GitHub/GitHubTasks.cs
+++ b/src/Ayaka.Nuke/GitHub/GitHubTasks.cs
@@ -10,6 +10,7 @@ using Serilog;
 /// <summary>
 ///     Provides tasks for interacting with the GitHub API.
 /// </summary>
+[ExcludeFromCodeCoverage]
 public static class GitHubTasks
 {
     /// <summary>

--- a/src/Ayaka.Nuke/GitHub/ICanGitHubRelease.cs
+++ b/src/Ayaka.Nuke/GitHub/ICanGitHubRelease.cs
@@ -19,6 +19,7 @@ public interface ICanGitHubRelease
     /// <summary>
     ///     Gets the base settings for creating release notes.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     sealed Configure<GitHubReleaseNotesSettings> GitHubReleaseNotesSettingsBase
         => notes => notes
             .SetRepositoryOwner(GitRepository.GetGitHubOwner())
@@ -33,12 +34,14 @@ public interface ICanGitHubRelease
     /// <remarks>
     ///     Override this to provide additional settings for the <see cref="IHaveGitHubReleaseTarget.GitHubRelease" /> target.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     Configure<GitHubReleaseNotesSettings> GitHubReleaseNotesSettings
         => notes => notes;
 
     /// <summary>
     ///     Gets the base settings for creating a GitHub release.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     sealed Configure<GitHubReleaseSettings> GitHubReleaseSettingsBase
         => release => release
             .SetRepositoryOwner(GitRepository.GetGitHubOwner())
@@ -54,10 +57,12 @@ public interface ICanGitHubRelease
     /// <remarks>
     ///     Override this to provide additional settings for the <see cref="IHaveGitHubReleaseTarget.GitHubRelease" /> target.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     Configure<GitHubReleaseSettings> GitHubReleaseSettings
         => release => release;
 
     /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
     Target IHaveGitHubReleaseTarget.GitHubRelease => target => target
         .Description("")
         .Unlisted()

--- a/src/Ayaka.Nuke/GitHub/IHaveGitHubToken.cs
+++ b/src/Ayaka.Nuke/GitHub/IHaveGitHubToken.cs
@@ -17,6 +17,7 @@ public interface IHaveGitHubToken
     /// <remarks>
     /// </remarks>
     [Parameter]
+    [ExcludeFromCodeCoverage]
     string? GitHubBaseUrl => TryGetValue(() => GitHubBaseUrl);
 
     /// <summary>
@@ -24,6 +25,7 @@ public interface IHaveGitHubToken
     /// </summary>
     [Parameter("The GitHub API token")]
     [Secret]
+    [ExcludeFromCodeCoverage]
     string? GitHubToken => TryGetValue(() => GitHubToken)
                            ?? GitHubActions.Instance?.Token;
 }

--- a/src/Ayaka.Nuke/ICanClean.cs
+++ b/src/Ayaka.Nuke/ICanClean.cs
@@ -17,6 +17,7 @@ public interface ICanClean
         IHaveCleanTarget
 {
     /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
     Target IHaveCleanTarget.Clean => target => target
         .Description("Cleans up various build directories")
         .Executes(() =>

--- a/src/Ayaka.Nuke/IHaveArtifacts.cs
+++ b/src/Ayaka.Nuke/IHaveArtifacts.cs
@@ -17,6 +17,7 @@ public interface IHaveArtifacts : IHave
     ///     If not overriden, defaults to <c><see cref="INukeBuild.RootDirectory" />/artifacts</c>.
     /// </remarks>
     [Parameter("The directory where artifacts are to be dropped", Name = "Artifacts")]
+    [ExcludeFromCodeCoverage]
     AbsolutePath ArtifactsDirectory => TryGetValue(() => ArtifactsDirectory)
                                        ?? RootDirectory / "artifacts";
 }

--- a/src/Ayaka.Nuke/IHaveCodeCoverage.cs
+++ b/src/Ayaka.Nuke/IHaveCodeCoverage.cs
@@ -16,5 +16,6 @@ public interface IHaveCodeCoverage : IHaveArtifacts
     /// <remarks>
     ///     If not overriden, defaults to <c><see cref="IHaveArtifacts.ArtifactsDirectory" />/coverage</c>.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     AbsolutePath CoverageDirectory => ArtifactsDirectory / "coverage";
 }

--- a/src/Ayaka.Nuke/IHaveGitRepository.cs
+++ b/src/Ayaka.Nuke/IHaveGitRepository.cs
@@ -15,5 +15,6 @@ public interface IHaveGitRepository : IHave
     /// </summary>
     [GitRepository]
     [Required]
+    [ExcludeFromCodeCoverage]
     GitRepository GitRepository => TryGetValue(() => GitRepository)!;
 }

--- a/src/Ayaka.Nuke/IHaveGitVersion.cs
+++ b/src/Ayaka.Nuke/IHaveGitVersion.cs
@@ -36,5 +36,6 @@ public interface IHaveGitVersion : IHave
     /// </summary>
     [GitVersion(NoFetch = true)]
     [Required]
+    [ExcludeFromCodeCoverage]
     GitVersion Versioning => TryGetValue(() => Versioning)!;
 }

--- a/src/Ayaka.Nuke/IHavePackageArtifacts.cs
+++ b/src/Ayaka.Nuke/IHavePackageArtifacts.cs
@@ -16,5 +16,6 @@ public interface IHavePackageArtifacts : IHaveArtifacts
     /// <remarks>
     ///     If not overriden, defaults to <c><see cref="IHaveArtifacts.ArtifactsDirectory" />/packages</c>.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     AbsolutePath PackagesDirectory => ArtifactsDirectory / "packages";
 }

--- a/src/Ayaka.Nuke/IHaveSolution.cs
+++ b/src/Ayaka.Nuke/IHaveSolution.cs
@@ -15,5 +15,6 @@ public interface IHaveSolution : IHave
     /// </summary>
     [Solution]
     [Required]
+    [ExcludeFromCodeCoverage]
     Solution Solution => TryGetValue(() => Solution)!;
 }

--- a/src/Ayaka.Nuke/IHaveSources.cs
+++ b/src/Ayaka.Nuke/IHaveSources.cs
@@ -16,5 +16,6 @@ public interface IHaveSources : IHave
     /// <remarks>
     ///     If not overriden, defaults to <c><see cref="IHave.RootDirectory" />/src</c>.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     AbsolutePath SourceDirectory => RootDirectory / "src";
 }

--- a/src/Ayaka.Nuke/IHaveTestArtifacts.cs
+++ b/src/Ayaka.Nuke/IHaveTestArtifacts.cs
@@ -16,5 +16,6 @@ public interface IHaveTestArtifacts : IHaveArtifacts
     /// <remarks>
     ///     If not overriden, defaults to <c><see cref="IHaveArtifacts.ArtifactsDirectory" />/test-results</c>.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     AbsolutePath TestResultsDirectory => ArtifactsDirectory / "test-results";
 }

--- a/src/Ayaka.Nuke/IHaveTests.cs
+++ b/src/Ayaka.Nuke/IHaveTests.cs
@@ -15,5 +15,6 @@ public interface IHaveTests : IHave
     /// <remarks>
     ///     If not overriden, defaults to <c><see cref="IHave.RootDirectory" />/tests</c>.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     AbsolutePath TestsDirectory => RootDirectory / "test";
 }

--- a/src/Ayaka.Nuke/NuGet/IHaveNuGetConfiguration.cs
+++ b/src/Ayaka.Nuke/NuGet/IHaveNuGetConfiguration.cs
@@ -18,6 +18,7 @@ public interface IHaveNuGetConfiguration : IHave
     ///     Gets the NuGet server URL.
     /// </summary>
     [Parameter("The NuGet server URL - Default is " + DefaultNuGetSource)]
+    [ExcludeFromCodeCoverage]
     string NuGetSource => TryGetValue(() => NuGetSource) ?? DefaultNuGetSource;
 
     /// <summary>
@@ -25,5 +26,6 @@ public interface IHaveNuGetConfiguration : IHave
     /// </summary>
     [Parameter("The NuGet API key")]
     [Secret]
+    [ExcludeFromCodeCoverage]
     string? NuGetApiKey => TryGetValue(() => NuGetApiKey);
 }


### PR DESCRIPTION
## Description

Most of the NUKE build stuff isn't really coverable. Thus it's now being excluded.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Codecov.io reporting

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
