### PR TITLE
fix: base url of docs page with is capitalized

### DIFF
--- a/docs/.vitepress/shared.ts
+++ b/docs/.vitepress/shared.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitepress';
 export const shared = defineConfig({
   title: 'Ayaka',
 
-  base: '/ayaka/',
+  base: '/Ayaka/',
 
   rewrites: {
     'en/:rest*': ':rest*',


### PR DESCRIPTION
## Description

Fixes the base URL of the docs page witch seems to be capitalized.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

None

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
