### PR TITLE
refactor: use non-obsolete AbsolutePath.Copy()

### DIFF
--- a/src/Ayaka.Nuke/DotNet/TargetDefinitionExtensions.cs
+++ b/src/Ayaka.Nuke/DotNet/TargetDefinitionExtensions.cs
@@ -4,7 +4,6 @@ namespace Ayaka.Nuke.DotNet;
 
 using global::Nuke.Common;
 using global::Nuke.Common.IO;
-using static global::Nuke.Common.IO.FileSystemTasks;
 
 [ExcludeFromCodeCoverage]
 internal static class TargetDefinitionExtensions
@@ -34,9 +33,7 @@ internal static class TargetDefinitionExtensions
                 {
                     var filename = $"{coverageFile.Parent!.Name}.cobertura.xml";
 
-                    CopyFile(
-                        coverageFile,
-                        coverageDirectory / filename);
+                    _ = coverageFile.Copy(coverageDirectory / filename);
                 }
             });
 }


### PR DESCRIPTION
## Description

Uses the non-obsolete `AbsolutePath.Copy()`

Fixes #79 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Manually

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
