### PR TITLE
feat: add VitePress lint target

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -88,7 +88,8 @@
         "ShipPublicApis",
         "Test",
         "VitePressBuild",
-        "VitePressInstall"
+        "VitePressInstall",
+        "VitePressLint"
       ]
     },
     "Verbosity": {

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -8,7 +8,9 @@ using Ayaka.Nuke.NuGet;
 using Ayaka.Nuke.PublicApi;
 using Ayaka.Nuke.VitePress;
 using Nuke.Common;
+using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Tools.Npm;
 
 [DotNetVerbosityMapping]
 partial class Build
@@ -35,6 +37,7 @@ partial class Build
         ICanDotNetValidate,
         ICanDotNetPush,
         ICanVitePressInstall,
+        ICanVitePressLint,
         ICanVitePressBuild,
         ICanGitHubRelease,
         ICanShipPublicApis
@@ -66,6 +69,11 @@ partial class Build
     Target Publish => target => target
         .Description("Publishes all NuGet packages in the Solution")
         .DependsOn<IHaveDotNetPushTarget>();
+
+    // Customize the VitePress linting
+    Configure<NpmRunSettings> ICanVitePressLint.VitePressLintSettings
+        => run => run
+            .SetCommand("lint:js");
 
     Target Docs => target => target
         .Description("Builds the Documentation")

--- a/src/Ayaka.Nuke/PublicAPI.Unshipped.txt
+++ b/src/Ayaka.Nuke/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 ﻿#nullable enable
+Ayaka.Nuke.VitePress.ICanVitePressLint
+Ayaka.Nuke.VitePress.ICanVitePressLint.VitePressLintSettings.get -> Nuke.Common.Tooling.Configure<Nuke.Common.Tools.Npm.NpmRunSettings!>!
+Ayaka.Nuke.VitePress.ICanVitePressLint.VitePressLintSettingsBase.get -> Nuke.Common.Tooling.Configure<Nuke.Common.Tools.Npm.NpmRunSettings!>!
+Ayaka.Nuke.VitePress.IHaveVitePressLintTarget
+Ayaka.Nuke.VitePress.IHaveVitePressLintTarget.VitePressLint.get -> Nuke.Common.Target!

--- a/src/Ayaka.Nuke/VitePress/ICanVitePressBuild.cs
+++ b/src/Ayaka.Nuke/VitePress/ICanVitePressBuild.cs
@@ -46,6 +46,7 @@ public interface ICanVitePressBuild
         .Description("Builds the VitePress site")
         .Unlisted()
         .DependsOn<IHaveVitePressInstallTarget>()
+        .TryDependsOn<IHaveVitePressLintTarget>()
         .Executes(() =>
         {
             _ = NpmTasks.NpmRun(

--- a/src/Ayaka.Nuke/VitePress/ICanVitePressLint.cs
+++ b/src/Ayaka.Nuke/VitePress/ICanVitePressLint.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.VitePress;
+
+using global::Nuke.Common;
+using global::Nuke.Common.Tooling;
+using global::Nuke.Common.Tools.Npm;
+
+/// <summary>
+///     Provides a target for linting a VitePress site to the <see cref="INukeLint" />.
+/// </summary>
+public interface ICanVitePressLint
+    : ICan,
+        IHaveDocumentation,
+        IHaveVitePressInstallTarget,
+        IHaveVitePressLintTarget
+{
+    /// <summary>
+    ///     Gets the base settings for linting the VitePress site.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    sealed Configure<NpmRunSettings> VitePressLintSettingsBase
+        => run => run
+            .SetProcessWorkingDirectory(DocsDirectory)
+            .SetCommand("lint")
+            .SetProcessLogOutput(Verbosity == Verbosity.Verbose);
+
+    /// <summary>
+    ///     Gets the additional settings for linting the VitePress site.
+    /// </summary>
+    /// <remarks>
+    ///     Override this to provide additional settings for the <see cref="IHaveVitePressLintTarget.VitePressLint" />
+    ///     target.
+    /// </remarks>
+    [ExcludeFromCodeCoverage]
+    Configure<NpmRunSettings> VitePressLintSettings
+        => run => run;
+
+    /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
+    Target IHaveVitePressLintTarget.VitePressLint => target => target
+        .Description("Lints the VitePress site")
+        .Unlisted()
+        .DependsOn<IHaveVitePressInstallTarget>()
+        .TryBefore<IHaveVitePressBuildTarget>()
+        .Executes(() =>
+        {
+            _ = NpmTasks.NpmRun(
+                npm => npm
+                    .Apply(VitePressLintSettingsBase)
+                    .Apply(VitePressLintSettings));
+        });
+}

--- a/src/Ayaka.Nuke/VitePress/IHaveVitePressLintTarget.cs
+++ b/src/Ayaka.Nuke/VitePress/IHaveVitePressLintTarget.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.Nuke.VitePress;
+
+using global::Nuke.Common;
+
+/// <summary>
+///     Indicates that a <see cref="INukeBuild" /> has a target for linting a VitePress site.
+/// </summary>
+public interface IHaveVitePressLintTarget : IHave
+{
+    /// <summary>
+    ///     Gets the target for linting a VitePress site.
+    /// </summary>
+    Target VitePressLint { get; }
+}


### PR DESCRIPTION
## Description

Adds a VitePress linting target which runs `lint` npm script in the `/docs` directory.
In case of Ayaka's docs, it uses the `lint:js` npm script which uses `eslint` to lint the documentation files.

Fixes #102 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Manually

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
