### PR TITLE
fix: VitePress styled block in code guidelines

### DIFF
--- a/.github/CODE_GUIDELINES.md
+++ b/.github/CODE_GUIDELINES.md
@@ -4,9 +4,9 @@ Ayaka uses an `.editorconfig` file that covers most of the coding style.
 
 This file is automatically used by Visual Studio and other editors to ensure that the code is formatted correctly.
 
-::: info
 The `.editorconfig` isn't flawless, but should give you a good starting point to what I expect.
-:::
+
+---
 
 For a more detailed overview regarding the code guidelines, please refer to the [Documentation].
 


### PR DESCRIPTION
## Description

Fixes a VitePress styled code block in the repository code guidelines.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Manually

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
