### PR TITLE
fix: regenerate nuke build schema

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,48 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "properties": {
-    "Artifacts": {
-      "type": "string",
-      "description": "The directory where artifacts are to be dropped"
-    },
-    "DotNetConfiguration": {
-      "type": "string",
-      "description": "The .NET build configuration - Default is 'Debug' (local) or 'Release' (server)",
-      "enum": [
-        "Debug",
-        "Release"
-      ]
-    },
-    "GitHubBaseUrl": {
-      "type": "string"
-    },
-    "GitHubToken": {
-      "type": "string",
-      "description": "The GitHub API token",
-      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-    },
-    "GitUserEmail": {
-      "type": "string",
-      "description": "The Git user email address"
-    },
-    "GitUserName": {
-      "type": "string",
-      "description": "The Git user name"
-    },
-    "NuGetApiKey": {
-      "type": "string",
-      "description": "The NuGet API key",
-      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-    },
-    "NuGetSource": {
-      "type": "string",
-      "description": "The NuGet server URL - Default is https://api.nuget.org/v3/index.json"
-    },
-    "Solution": {
-      "type": "string",
-      "description": "Path to a solution file that is automatically loaded"
-    }
-  },
   "definitions": {
     "Host": {
       "type": "string",
@@ -160,5 +117,54 @@
       }
     }
   },
-  "$ref": "#/definitions/NukeBuild"
+  "allOf": [
+    {
+      "properties": {
+        "Artifacts": {
+          "type": "string",
+          "description": "The directory where artifacts are to be dropped"
+        },
+        "DotNetConfiguration": {
+          "type": "string",
+          "description": "The .NET build configuration - Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
+        "GitHubBaseUrl": {
+          "type": "string"
+        },
+        "GitHubToken": {
+          "type": "string",
+          "description": "The GitHub API token",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
+        "GitUserEmail": {
+          "type": "string",
+          "description": "The Git user email address"
+        },
+        "GitUserName": {
+          "type": "string",
+          "description": "The Git user name"
+        },
+        "NuGetApiKey": {
+          "type": "string",
+          "description": "The NuGet API key",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
+        "NuGetSource": {
+          "type": "string",
+          "description": "The NuGet server URL - Default is https://api.nuget.org/v3/index.json"
+        },
+        "Solution": {
+          "type": "string",
+          "description": "Path to a solution file that is automatically loaded"
+        }
+      }
+    },
+    {
+      "$ref": "#/definitions/NukeBuild"
+    }
+  ]
 }


### PR DESCRIPTION
## Description

With the last update of the `Nuke` NuGet packages the build schema got changed.
This now breaks the after-release workflow.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Local build execution

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
