### PR TITLE
fix: install net6 alongside the global.json one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4
+        with:
+          dotnet-version: 6.x # Required for dotnet-validate
+          global-json-file: ./global.json # Required, otherwise only the versions above get installed
 
       - name: Restore .NET Tools
         run: |

--- a/docs/en/guide/packages/nuke/build-components/dotnet.md
+++ b/docs/en/guide/packages/nuke/build-components/dotnet.md
@@ -493,6 +493,13 @@ build project file.
 See [Executing CLI Tools] for more information.
 :::
 
+::: warning
+Please note that `dotnet-validate` with version `0.0.1-preview.304` and below still requires .NET 6 SDK installed
+on the build system.
+
+Since the support for .NET 6 ended in Nov 2024, you likely have to install it manually.
+:::
+
 By default, `NuGetPackagesToPush` represents all packages (`*.nupkg`) within the `PackagesDirectory` directory of the
 [`IHavePackageArtifacts`] build context component.
 


### PR DESCRIPTION
## Description

Installs .NET 6 alongside the SDK specified by `global.json`.
Sadly, `dotnet-validate` still depends on .NET 6 and hasn't been updated in a while.

### Type of change

<!-- Please delete options that are not relevant. --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (does not change any other code than documentation)

## How has this been tested?

GitHub Actions

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
