### PR TITLE
chore: fix codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Upload Coverage
         uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5
         with:
+          version: v10.0.1 # Later versions break file search
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           directory: ${{ github.workspace }}/artifacts/coverage
@@ -60,7 +61,7 @@ jobs:
         with:
           name: packages
           path: ${{ github.workspace }}/artifacts/packages
-          if-no-files-found: error
+          if-no-files-found: error          
 
   build-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Pinning the version of the codecov CLI as a workaround until they either publish proper docs or fix the issue.
Newer versions can't seem to find files.

### Type of change

<!-- Please delete options that are not relevant. --->

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

If the PR build succeeds, then it works :)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
