### PR TITLE
chore: add support to flag individual NuGet packages as preview

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,15 @@
 mode: ContinuousDeployment
-continuous-delivery-fallback-tag: 'preview'
 assembly-versioning-scheme: MajorMinorPatch
 major-version-bump-message: "^(chore|docs|feat|fix|refactor|revert|style|test)(\\([\\w\\s-]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
 minor-version-bump-message: "^(feat)(\\([\\w\\s-]*\\))?:"
 patch-version-bump-message: "^(chore|docs|fix|refactor|revert|style|test)(\\([\\w\\s-]*\\))?:"
+branches:
+  main:
+    mode: ContinuousDeployment
+    tag: preview
+  pull-request:
+    mode: ContinuousDeployment
+    tag: pr
+    source-branches:
+      - main
+      - feature

--- a/src/Ayaka.MultiTenancy.Abstractions/Ayaka.MultiTenancy.Abstractions.csproj
+++ b/src/Ayaka.MultiTenancy.Abstractions/Ayaka.MultiTenancy.Abstractions.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <VersionSuffix>preview</VersionSuffix>
     <PackageDescription>Provides abstractions for multi-tenanted applications. $(PackageDescriptionAppendix)</PackageDescription>
     <PackageTags>$(PackageCommonTags);multi-tenancy</PackageTags>
   </PropertyGroup>

--- a/src/Ayaka.MultiTenancy/Ayaka.MultiTenancy.csproj
+++ b/src/Ayaka.MultiTenancy/Ayaka.MultiTenancy.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <VersionSuffix>preview</VersionSuffix>
     <PackageDescription>Provides functionality for creating multi-tenanted applications. $(PackageDescriptionAppendix)</PackageDescription>
     <PackageTags>$(PackageCommonTags);multi-tenancy</PackageTags>
   </PropertyGroup>

--- a/src/Ayaka.Nuke/DotNet/ICanDotNetBuild.cs
+++ b/src/Ayaka.Nuke/DotNet/ICanDotNetBuild.cs
@@ -59,7 +59,7 @@ public interface ICanDotNetBuild
                 summary => summary
                     .WhenNotNull(
                         this as IHaveGitVersion,
-                        (s, o) => s.AddPair("Version", o.Versioning.NuGetVersionV2))
+                        (s, o) => s.AddPair("Version", o.Versioning.SemVer))
             );
 
             _ = DotNetTasks.DotNetBuild(

--- a/src/Ayaka.Nuke/DotNet/ICanDotNetPack.cs
+++ b/src/Ayaka.Nuke/DotNet/ICanDotNetPack.cs
@@ -34,7 +34,7 @@ public interface ICanDotNetPack
                 (d, o) => d.SetRepositoryUrl(o.GitRepository.HttpsUrl))
             .WhenNotNull(
                 this as IHaveGitVersion,
-                (d, o) => d.SetVersion(o.Versioning.NuGetVersionV2));
+                (d, o) => d.SetVersion(o.Versioning.SemVer));
 
     /// <summary>
     ///     Gets the additional settings for packing the current solution.


### PR DESCRIPTION
## Description

Adds support to flag individual NuGet packages as preview when running the NUKE build.

### Type of change

<!-- Please delete options that are not relevant. --->

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Local testing using different tags, branches, etc. and then running `nuke Pack`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
