### PR TITLE
feat: add request tenancy middleware

### DIFF
--- a/Ayaka.sln
+++ b/Ayaka.sln
@@ -43,6 +43,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ayaka.MultiTenancy", "src\A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ayaka.MultiTenancy.Tests", "test\Ayaka.MultiTenancy.Tests\Ayaka.MultiTenancy.Tests.csproj", "{D446A2EF-62AC-4F9A-AE2B-85A712BCC6E4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ayaka.MultiTenancy.AspNetCore", "src\Ayaka.MultiTenancy.AspNetCore\Ayaka.MultiTenancy.AspNetCore.csproj", "{CA0F2000-FC57-44DE-8103-F0372D003EF8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ayaka.MultiTenancy.AspNetCore.Tests", "test\Ayaka.MultiTenancy.AspNetCore.Tests\Ayaka.MultiTenancy.AspNetCore.Tests.csproj", "{26A65F54-5CDD-4970-96DA-0B2ADE3BD64E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,6 +75,14 @@ Global
 		{D446A2EF-62AC-4F9A-AE2B-85A712BCC6E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D446A2EF-62AC-4F9A-AE2B-85A712BCC6E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D446A2EF-62AC-4F9A-AE2B-85A712BCC6E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CA0F2000-FC57-44DE-8103-F0372D003EF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA0F2000-FC57-44DE-8103-F0372D003EF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA0F2000-FC57-44DE-8103-F0372D003EF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA0F2000-FC57-44DE-8103-F0372D003EF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26A65F54-5CDD-4970-96DA-0B2ADE3BD64E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26A65F54-5CDD-4970-96DA-0B2ADE3BD64E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26A65F54-5CDD-4970-96DA-0B2ADE3BD64E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26A65F54-5CDD-4970-96DA-0B2ADE3BD64E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -83,6 +95,8 @@ Global
 		{6779F6F7-2E31-4D9C-9DA2-0097444C3113} = {E3E1A4B0-3D9E-4F1B-9BA2-16E21CEF43D6}
 		{AD16ED8A-F3F3-4D60-BA3E-4C143680DDE5} = {E3E1A4B0-3D9E-4F1B-9BA2-16E21CEF43D6}
 		{D446A2EF-62AC-4F9A-AE2B-85A712BCC6E4} = {4767B628-8774-4CBA-A1DF-ED27A2CFA272}
+		{CA0F2000-FC57-44DE-8103-F0372D003EF8} = {E3E1A4B0-3D9E-4F1B-9BA2-16E21CEF43D6}
+		{26A65F54-5CDD-4970-96DA-0B2ADE3BD64E} = {4767B628-8774-4CBA-A1DF-ED27A2CFA272}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E47191B9-F1B0-4A60-955E-ACAE410BD5DF}

--- a/src/Ayaka.MultiTenancy.AspNetCore/Ayaka.MultiTenancy.AspNetCore.csproj
+++ b/src/Ayaka.MultiTenancy.AspNetCore/Ayaka.MultiTenancy.AspNetCore.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <VersionSuffix>preview</VersionSuffix>
+    <PackageDescription>Provides ASP.NET core specific extensions for multi-tenanted applications. $(PackageDescriptionAppendix)</PackageDescription>
+    <PackageTags>$(PackageCommonTags);multi-tenancy;asp.net core</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ayaka.MultiTenancy.Abstractions\Ayaka.MultiTenancy.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Ayaka.MultiTenancy.AspNetCore/DependencyInjection/ApplicationBuilderExtensions.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/DependencyInjection/ApplicationBuilderExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.DependencyInjection;
+
+using Ayaka.MultiTenancy.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+///     Extension methods for <see cref="IApplicationBuilder"/>.
+/// </summary>
+public static class ApplicationBuilderExtensions
+{
+    /// <summary>
+    ///     Adds the <see cref="RequestTenancyMiddleware"/> to automatically detect the tenant based on the request.
+    /// </summary>
+    /// <param name="app">The <see cref="IApplicationBuilder"/> to add the middleware to.</param>
+    /// <returns>The same <see cref="IApplicationBuilder"/>.</returns>
+    public static IApplicationBuilder UseMultiTenancy(this IApplicationBuilder app)
+    {
+        VerifyServiceAreRegistered(app);
+        return app.UseMiddleware<RequestTenancyMiddleware>();
+    }
+
+    private static void VerifyServiceAreRegistered(IApplicationBuilder app)
+    {
+        var serviceProviderIsService = app.ApplicationServices.GetService<IServiceProviderIsService>();
+        if (serviceProviderIsService != null && !serviceProviderIsService.IsService(typeof(IOptions<ITenantContextAccessor>)))
+        {
+            throw new InvalidOperationException(
+                $"Unable to find the required services. " +
+                $"Please add all the required services by calling '{nameof(IServiceCollection)}.AddMultiTenancy()' in the application startup code.");
+        }
+    }
+}

--- a/src/Ayaka.MultiTenancy.AspNetCore/DependencyInjection/ApplicationBuilderExtensions.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/DependencyInjection/ApplicationBuilderExtensions.cs
@@ -26,7 +26,7 @@ public static class ApplicationBuilderExtensions
     private static void VerifyServiceAreRegistered(IApplicationBuilder app)
     {
         var serviceProviderIsService = app.ApplicationServices.GetService<IServiceProviderIsService>();
-        if (serviceProviderIsService != null && !serviceProviderIsService.IsService(typeof(IOptions<ITenantContextAccessor>)))
+        if (serviceProviderIsService != null && !serviceProviderIsService.IsService(typeof(ITenantContextAccessor)))
         {
             throw new InvalidOperationException(
                 $"Unable to find the required services. " +

--- a/src/Ayaka.MultiTenancy.AspNetCore/DependencyInjection/MultiTenancyBuilderExtensions.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/DependencyInjection/MultiTenancyBuilderExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.DependencyInjection;
+
+using Ayaka.MultiTenancy.AspNetCore;
+
+/// <summary>
+///     Extension methods for <see cref="IMultiTenancyBuilder" />.
+/// </summary>
+public static class MultiTenancyBuilderExtensions
+{
+    /// <summary>
+    ///     Configures the <see cref="RequestTenancyMiddleware"/> middleware.
+    /// </summary>
+    /// <param name="builder">The <see cref="IMultiTenancyBuilder"/> to configure the request tenancy on.</param>
+    /// <param name="configure">A delegate to configure the <see cref="RequestTenancyOptions"/>.</param>
+    /// <returns>The same <see cref="IMultiTenancyBuilder"/>.</returns>
+    public static IMultiTenancyBuilder ConfigureRequestTenancy(this IMultiTenancyBuilder builder, Action<RequestTenancyBuilder> configure)
+    {
+        var requestTenancyBuilder = new RequestTenancyBuilder(builder);
+        configure(requestTenancyBuilder);
+
+        requestTenancyBuilder.ConfigureServices();
+
+        return builder;
+    }
+}

--- a/src/Ayaka.MultiTenancy.AspNetCore/DependencyInjection/RequestTenancyBuilder.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/DependencyInjection/RequestTenancyBuilder.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.DependencyInjection;
+
+/// <summary>
+///     A builder for configuring <see cref="RequestTenancyOptions"/> used by the <see cref="RequestTenancyMiddleware"/>.
+/// </summary>
+public sealed class RequestTenancyBuilder
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="RequestTenancyBuilder"/> class.
+    /// </summary>
+    /// <param name="multiTenancy">The <see cref="IMultiTenancyBuilder" /> to configure request tenancy on.</param>
+    internal RequestTenancyBuilder(IMultiTenancyBuilder multiTenancy)
+    {
+        MultiTenancy = multiTenancy;
+    }
+
+    /// <summary>
+    ///     Gets the <see cref="IMultiTenancyBuilder"/> where request tenancy is configured.
+    /// </summary>
+    public IMultiTenancyBuilder MultiTenancy { get; }
+
+    internal void ConfigureServices()
+    {
+        // Ability to resolve IOptions<RequestTenancyOptions>
+        var optionBuilder = MultiTenancy.Services.AddOptions<RequestTenancyOptions>();
+    }
+}

--- a/src/Ayaka.MultiTenancy.AspNetCore/DependencyInjection/RequestTenancyBuilder.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/DependencyInjection/RequestTenancyBuilder.cs
@@ -2,11 +2,17 @@
 
 namespace Ayaka.MultiTenancy.DependencyInjection;
 
+using Ayaka.MultiTenancy.AspNetCore;
+using Ayaka.MultiTenancy.AspNetCore.Detection;
+using Microsoft.Extensions.DependencyInjection;
+
 /// <summary>
 ///     A builder for configuring <see cref="RequestTenancyOptions"/> used by the <see cref="RequestTenancyMiddleware"/>.
 /// </summary>
 public sealed class RequestTenancyBuilder
 {
+    private readonly List<Action<RequestTenancyOptions, IServiceProvider>> _configureActions = [];
+
     /// <summary>
     ///     Initializes a new instance of the <see cref="RequestTenancyBuilder"/> class.
     /// </summary>
@@ -21,9 +27,98 @@ public sealed class RequestTenancyBuilder
     /// </summary>
     public IMultiTenancyBuilder MultiTenancy { get; }
 
+    /// <summary>
+    ///     Configures the request tenancy to detect the tenant from a request header with the specified
+    ///     <paramref name="headerName"/>.
+    /// </summary>
+    /// <param name="headerName">The name of the header to read the tenant from.</param>
+    /// <returns>The same <see cref="RequestTenancyBuilder"/>.</returns>
+    public RequestTenancyBuilder DetectFromRequestHeader(string headerName)
+        => AddStrategy(sp => CreateStrategyInstance(sp, typeof(FromRequestHeaderStrategy), headerName));
+
+    /// <summary>
+    ///     Configures the request tenancy to detect the tenant from the request host.
+    /// </summary>
+    /// <remarks>
+    ///     Takes the left-most part of the host name as tenant identifier.
+    ///     <list type="table">
+    ///        <item>
+    ///           <term>example.com</term>
+    ///            <description>=> example</description>
+    ///       </item>
+    ///           <item>
+    ///           <term>sub.example.com</term>
+    ///           <description>=> sub</description>
+    ///       </item>
+    ///       <item>
+    ///           <term>deep-sub.sub.example.com</term>
+    ///           <description>=> deep-sub</description>
+    ///       </item>
+    ///     </list>
+    ///     <para>
+    ///         Please note that <c>localhost</c> and host names with only one part are not considered valid tenant
+    ///         identifiers.
+    ///     </para>
+    /// </remarks>
+    /// <returns>The same <see cref="RequestTenancyBuilder"/>.</returns>
+    public RequestTenancyBuilder DetectFromRequestHost()
+        => AddStrategy(sp => CreateStrategyInstance(sp, typeof(FromRequestHostStrategy)));
+
+    /// <summary>
+    ///     Configures the request tenancy to detect the tenant using an instance of the specified
+    ///     <typeparamref name="TDetectionStrategy"/> strategy.
+    /// </summary>
+    /// <remarks>
+    ///     Automatically injects constructor dependencies during instantiation.
+    /// </remarks>
+    /// <typeparam name="TDetectionStrategy">The type of the strategy to use.</typeparam>
+    /// <returns>The same <see cref="RequestTenancyBuilder"/>.</returns>
+    public RequestTenancyBuilder DetectUsing<TDetectionStrategy>()
+        where TDetectionStrategy : ITenantDetectionStrategy
+        => AddStrategy(sp => CreateStrategyInstance(sp, typeof(TDetectionStrategy)));
+
+    /// <summary>
+    ///    Configures the request tenancy to detect the tenant using the specified <paramref name="strategy"/>.
+    /// </summary>
+    /// <param name="strategy">The strategy to use.</param>
+    /// <returns>The same <see cref="RequestTenancyBuilder"/>.</returns>
+    public RequestTenancyBuilder DetectUsing(ITenantDetectionStrategy strategy)
+        => AddStrategy(_ => strategy);
+
     internal void ConfigureServices()
     {
         // Ability to resolve IOptions<RequestTenancyOptions>
         var optionBuilder = MultiTenancy.Services.AddOptions<RequestTenancyOptions>();
+
+        if (_configureActions.Count > 0)
+        {
+            // Apply them custom configuration actions
+            _ = optionBuilder.Configure<IServiceProvider>((opts, sp) =>
+            {
+                foreach (var action in _configureActions)
+                {
+                    action(opts, sp);
+                }
+            });
+        }
+    }
+
+    private static ITenantDetectionStrategy CreateStrategyInstance(
+        IServiceProvider serviceProvider,
+        Type strategyType,
+        params object[] args)
+        => (ITenantDetectionStrategy)ActivatorUtilities.CreateInstance(
+            serviceProvider,
+            strategyType,
+            args);
+
+    private RequestTenancyBuilder AddStrategy(Func<IServiceProvider, ITenantDetectionStrategy> factory)
+    {
+        _configureActions.Add(
+            (opts, sp) =>
+                opts.DetectionStrategies
+                    .Add(factory(sp)));
+
+        return this;
     }
 }

--- a/src/Ayaka.MultiTenancy.AspNetCore/Detection/FromRequestHeaderStrategy.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/Detection/FromRequestHeaderStrategy.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore.Detection;
+
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+///     Represents a strategy for detecting the tenant from a request header.
+/// </summary>
+public sealed class FromRequestHeaderStrategy : ITenantDetectionStrategy
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="FromRequestHeaderStrategy"/> class.
+    /// </summary>
+    /// <param name="headerName">The name of the requests header to read the tenant from.</param>
+    public FromRequestHeaderStrategy(string headerName)
+    {
+        HeaderName = headerName;
+    }
+
+    /// <summary>
+    ///     Gets the name of the requests header to read the tenant from.
+    /// </summary>
+    public string HeaderName { get; }
+
+    /// <inheritdoc />
+    public Task<string?> TryDetectAsync(HttpContext context)
+    {
+        var headers = context.Request.Headers;
+
+        if (!headers.TryGetValue(HeaderName, out var headerValues))
+        {
+            return Task.FromResult<string?>(null);
+        }
+
+        string? headerValue;
+
+        // Catch possible multiple header values
+        if (headerValues.Count > 1)
+        {
+            // Log.MultipleHeaderValuesFound(_logger, _headerName);
+            headerValue = headerValues[0];
+        }
+        else
+        {
+            headerValue = headerValues;
+        }
+
+        // Catch possible empty or whitespace value
+        if (string.IsNullOrWhiteSpace(headerValue))
+        {
+            return Task.FromResult<string?>(null);
+        }
+
+        var tenantId = headerValue;
+
+        return Task.FromResult<string?>(tenantId);
+    }
+}

--- a/src/Ayaka.MultiTenancy.AspNetCore/Detection/FromRequestHostStrategy.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/Detection/FromRequestHostStrategy.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore.Detection;
+
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+///     Represents a strategy for detecting the tenant from the request host.
+/// </summary>
+public sealed class FromRequestHostStrategy : ITenantDetectionStrategy
+{
+    /// <inheritdoc />
+    public Task<string?> TryDetectAsync(HttpContext context)
+    {
+        if (!context.Request.Host.HasValue)
+        {
+            return Task.FromResult<string?>(null);
+        }
+
+        var host = context.Request.Host.Host;
+
+        var parts = host.Split('.', StringSplitOptions.RemoveEmptyEntries);
+
+        // localhost => 1 (e.g. not enough parts)
+        // example.com => 2 (e.g. enough parts)
+        // sub.example.com => 3 (e.g. enough parts)
+        if (parts.Length <= 1)
+        {
+            return Task.FromResult<string?>(null);
+        }
+
+        // Use the left-most part as tenant identifier
+        var tenantId = parts[0];
+
+        return Task.FromResult<string?>(tenantId);
+    }
+}

--- a/src/Ayaka.MultiTenancy.AspNetCore/Detection/ITenantDetectionStrategy.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/Detection/ITenantDetectionStrategy.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore.Detection;
+
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+///     Provides a strategy to detect the tenant based on the <see cref="HttpContext"/> of the current request.
+/// </summary>
+public interface ITenantDetectionStrategy
+{
+    /// <summary>
+    ///     Tries to detect the tenant based on the <paramref name="context"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Instead of throwing an exception, this method should return <see langword="null"/> if the tenant could
+    ///     not be detected. This allows another strategy to try to detect the tenant, if one is configured.
+    /// </remarks>
+    /// <param name="context">The <see cref="HttpContent"/> of the current request.</param>
+    /// <returns>
+    ///     A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the tenant identifier,
+    ///     if one could be detected; otherwise, <see langword="null"/>.
+    /// </returns>
+    Task<string?> TryDetectAsync(HttpContext context);
+}

--- a/src/Ayaka.MultiTenancy.AspNetCore/DisableMultiTenancyAttribute.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/DisableMultiTenancyAttribute.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore;
+
+/// <summary>
+///     Specifies that automatic tenant detection should be disabled for the endpoint.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public sealed class DisableMultiTenancyAttribute : Attribute;

--- a/src/Ayaka.MultiTenancy.AspNetCore/PACKAGE.md
+++ b/src/Ayaka.MultiTenancy.AspNetCore/PACKAGE.md
@@ -1,0 +1,16 @@
+## About
+
+Provides ASP.NET core specific extensions for multi-tenanted applications.
+
+## Key Features
+
+## How to Use
+
+## Additional Documentation
+
+See [the documentation](https://xzelsius.github.io/Ayaka/guide/packages/multi-tenancy) for more details.
+
+## Feedback & Contributing
+
+`Ayaka` is an open-source project and welcomes contributions. If you have any ideas, improvements or issues, please open an issue
+or a pull request at [the GitHub repository](https://github.com/Xzelsius/Ayaka).

--- a/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Shipped.txt
+++ b/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Unshipped.txt
+++ b/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Unshipped.txt
+++ b/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Unshipped.txt
@@ -8,3 +8,9 @@ Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHostStrategy.FromRequestHostS
 Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHostStrategy.TryDetectAsync(Microsoft.AspNetCore.Http.HttpContext! context) -> System.Threading.Tasks.Task<string?>!
 Ayaka.MultiTenancy.AspNetCore.Detection.ITenantDetectionStrategy
 Ayaka.MultiTenancy.AspNetCore.Detection.ITenantDetectionStrategy.TryDetectAsync(Microsoft.AspNetCore.Http.HttpContext! context) -> System.Threading.Tasks.Task<string?>!
+Ayaka.MultiTenancy.AspNetCore.RequestTenancyOptions
+Ayaka.MultiTenancy.AspNetCore.RequestTenancyOptions.RequestTenancyOptions() -> void
+Ayaka.MultiTenancy.DependencyInjection.MultiTenancyBuilderExtensions
+Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder
+Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder.MultiTenancy.get -> Ayaka.MultiTenancy.DependencyInjection.IMultiTenancyBuilder!
+static Ayaka.MultiTenancy.DependencyInjection.MultiTenancyBuilderExtensions.ConfigureRequestTenancy(this Ayaka.MultiTenancy.DependencyInjection.IMultiTenancyBuilder! builder, System.Action<Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder!>! configure) -> Ayaka.MultiTenancy.DependencyInjection.IMultiTenancyBuilder!

--- a/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Unshipped.txt
+++ b/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Unshipped.txt
@@ -8,10 +8,16 @@ Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHostStrategy.FromRequestHostS
 Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHostStrategy.TryDetectAsync(Microsoft.AspNetCore.Http.HttpContext! context) -> System.Threading.Tasks.Task<string?>!
 Ayaka.MultiTenancy.AspNetCore.Detection.ITenantDetectionStrategy
 Ayaka.MultiTenancy.AspNetCore.Detection.ITenantDetectionStrategy.TryDetectAsync(Microsoft.AspNetCore.Http.HttpContext! context) -> System.Threading.Tasks.Task<string?>!
+Ayaka.MultiTenancy.AspNetCore.DisableMultiTenancyAttribute
+Ayaka.MultiTenancy.AspNetCore.DisableMultiTenancyAttribute.DisableMultiTenancyAttribute() -> void
+Ayaka.MultiTenancy.AspNetCore.RequestTenancyMiddleware
+Ayaka.MultiTenancy.AspNetCore.RequestTenancyMiddleware.InvokeAsync(Microsoft.AspNetCore.Http.HttpContext! context) -> System.Threading.Tasks.Task!
+Ayaka.MultiTenancy.AspNetCore.RequestTenancyMiddleware.RequestTenancyMiddleware(Microsoft.AspNetCore.Http.RequestDelegate! next, Microsoft.Extensions.Options.IOptions<Ayaka.MultiTenancy.AspNetCore.RequestTenancyOptions!>! options, Ayaka.MultiTenancy.ITenantContextAccessor! accessor, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
 Ayaka.MultiTenancy.AspNetCore.RequestTenancyOptions
 Ayaka.MultiTenancy.AspNetCore.RequestTenancyOptions.DetectionStrategies.get -> System.Collections.Generic.IList<Ayaka.MultiTenancy.AspNetCore.Detection.ITenantDetectionStrategy!>!
 Ayaka.MultiTenancy.AspNetCore.RequestTenancyOptions.DetectionStrategies.init -> void
 Ayaka.MultiTenancy.AspNetCore.RequestTenancyOptions.RequestTenancyOptions() -> void
+Ayaka.MultiTenancy.DependencyInjection.ApplicationBuilderExtensions
 Ayaka.MultiTenancy.DependencyInjection.MultiTenancyBuilderExtensions
 Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder
 Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder.DetectFromRequestHeader(string! headerName) -> Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder!
@@ -19,4 +25,5 @@ Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder.DetectFromRequestHo
 Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder.DetectUsing(Ayaka.MultiTenancy.AspNetCore.Detection.ITenantDetectionStrategy! strategy) -> Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder!
 Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder.DetectUsing<TDetectionStrategy>() -> Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder!
 Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder.MultiTenancy.get -> Ayaka.MultiTenancy.DependencyInjection.IMultiTenancyBuilder!
+static Ayaka.MultiTenancy.DependencyInjection.ApplicationBuilderExtensions.UseMultiTenancy(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 static Ayaka.MultiTenancy.DependencyInjection.MultiTenancyBuilderExtensions.ConfigureRequestTenancy(this Ayaka.MultiTenancy.DependencyInjection.IMultiTenancyBuilder! builder, System.Action<Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder!>! configure) -> Ayaka.MultiTenancy.DependencyInjection.IMultiTenancyBuilder!

--- a/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Unshipped.txt
+++ b/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Unshipped.txt
@@ -9,8 +9,14 @@ Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHostStrategy.TryDetectAsync(M
 Ayaka.MultiTenancy.AspNetCore.Detection.ITenantDetectionStrategy
 Ayaka.MultiTenancy.AspNetCore.Detection.ITenantDetectionStrategy.TryDetectAsync(Microsoft.AspNetCore.Http.HttpContext! context) -> System.Threading.Tasks.Task<string?>!
 Ayaka.MultiTenancy.AspNetCore.RequestTenancyOptions
+Ayaka.MultiTenancy.AspNetCore.RequestTenancyOptions.DetectionStrategies.get -> System.Collections.Generic.IList<Ayaka.MultiTenancy.AspNetCore.Detection.ITenantDetectionStrategy!>!
+Ayaka.MultiTenancy.AspNetCore.RequestTenancyOptions.DetectionStrategies.init -> void
 Ayaka.MultiTenancy.AspNetCore.RequestTenancyOptions.RequestTenancyOptions() -> void
 Ayaka.MultiTenancy.DependencyInjection.MultiTenancyBuilderExtensions
 Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder
+Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder.DetectFromRequestHeader(string! headerName) -> Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder!
+Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder.DetectFromRequestHost() -> Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder!
+Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder.DetectUsing(Ayaka.MultiTenancy.AspNetCore.Detection.ITenantDetectionStrategy! strategy) -> Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder!
+Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder.DetectUsing<TDetectionStrategy>() -> Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder!
 Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder.MultiTenancy.get -> Ayaka.MultiTenancy.DependencyInjection.IMultiTenancyBuilder!
 static Ayaka.MultiTenancy.DependencyInjection.MultiTenancyBuilderExtensions.ConfigureRequestTenancy(this Ayaka.MultiTenancy.DependencyInjection.IMultiTenancyBuilder! builder, System.Action<Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder!>! configure) -> Ayaka.MultiTenancy.DependencyInjection.IMultiTenancyBuilder!

--- a/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Unshipped.txt
+++ b/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Unshipped.txt
@@ -1,4 +1,8 @@
 #nullable enable
+Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHeaderStrategy
+Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHeaderStrategy.FromRequestHeaderStrategy(string! headerName) -> void
+Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHeaderStrategy.HeaderName.get -> string!
+Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHeaderStrategy.TryDetectAsync(Microsoft.AspNetCore.Http.HttpContext! context) -> System.Threading.Tasks.Task<string?>!
 Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHostStrategy
 Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHostStrategy.FromRequestHostStrategy() -> void
 Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHostStrategy.TryDetectAsync(Microsoft.AspNetCore.Http.HttpContext! context) -> System.Threading.Tasks.Task<string?>!

--- a/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Unshipped.txt
+++ b/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHostStrategy
+Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHostStrategy.FromRequestHostStrategy() -> void
+Ayaka.MultiTenancy.AspNetCore.Detection.FromRequestHostStrategy.TryDetectAsync(Microsoft.AspNetCore.Http.HttpContext! context) -> System.Threading.Tasks.Task<string?>!
+Ayaka.MultiTenancy.AspNetCore.Detection.ITenantDetectionStrategy
+Ayaka.MultiTenancy.AspNetCore.Detection.ITenantDetectionStrategy.TryDetectAsync(Microsoft.AspNetCore.Http.HttpContext! context) -> System.Threading.Tasks.Task<string?>!

--- a/src/Ayaka.MultiTenancy.AspNetCore/RequestTenancyMiddleware.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/RequestTenancyMiddleware.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+///     Enables automatic tenant detection based on the current <see cref="HttpRequest"/>.
+/// </summary>
+public sealed partial class RequestTenancyMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly RequestTenancyOptions _options;
+    private readonly ITenantContextAccessor _accessor;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="RequestTenancyMiddleware"/> class.
+    /// </summary>
+    /// <param name="next">The <see cref="RequestDelegate"/> representing the next middleware in the pipeline.</param>
+    /// <param name="options">The <see cref="RequestTenancyOptions"/> representing the options for the middleware.</param>
+    /// <param name="accessor">The <see cref="ITenantContextAccessor"/> used to store the detected tenant.</param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used for logging.</param>
+    public RequestTenancyMiddleware(
+        RequestDelegate next,
+        IOptions<RequestTenancyOptions> options,
+        ITenantContextAccessor accessor,
+        ILoggerFactory loggerFactory)
+    {
+        _next = next;
+        _options = options.Value;
+        _accessor = accessor;
+        _logger = loggerFactory.CreateLogger<RequestTenancyMiddleware>();
+    }
+
+    /// <summary>
+    ///     Invokes the logic of the middleware.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/>.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public Task InvokeAsync(HttpContext context)
+    {
+        var endpoint = context.GetEndpoint();
+
+        // Check whether we should skip tenant detection
+        if (endpoint?.Metadata.GetMetadata<DisableMultiTenancyAttribute>() is not null)
+        {
+            RequestTenancyLog.EndpointSkipsTenantDetection(_logger);
+            return _next(context);
+        }
+
+        return InvokeInternal(context);
+    }
+
+    private async Task InvokeInternal(HttpContext context)
+    {
+        if (_accessor.TenantContext is not null)
+        {
+            throw new InvalidOperationException("Tenant was already set previously in the request pipeline");
+        }
+
+        if (_options.DetectionStrategies.Count == 0)
+        {
+            throw new InvalidOperationException("No tenant detection strategies are configured");
+        }
+
+        var tenant = await TryDetectTenant(context);
+        if (tenant is not null)
+        {
+            _accessor.TenantContext = new TenantContext(tenant, tenant);
+        }
+
+        await _next(context);
+    }
+
+    private async Task<string?> TryDetectTenant(HttpContext context)
+    {
+        foreach (var strategy in _options.DetectionStrategies)
+        {
+            var tenant = await strategy.TryDetectAsync(context);
+            if (tenant is not null)
+            {
+                RequestTenancyLog.TenantDetected(_logger, tenant, strategy.GetType().Name);
+                return tenant;
+            }
+        }
+
+        RequestTenancyLog.UnableToDetectTenant(_logger);
+        return null;
+    }
+
+    private static partial class RequestTenancyLog
+    {
+        [LoggerMessage(1, LogLevel.Debug, "Endpoint is marked to skip tenant detection.")]
+        public static partial void EndpointSkipsTenantDetection(ILogger logger);
+
+        [LoggerMessage(2, LogLevel.Debug, "Tenant '{Tenant}' was detected using strategy '{Strategy}'.")]
+        public static partial void TenantDetected(ILogger logger, string tenant, string strategy);
+
+        [LoggerMessage(3, LogLevel.Debug, "Unable to detect tenant.")]
+        public static partial void UnableToDetectTenant(ILogger logger);
+    }
+}

--- a/src/Ayaka.MultiTenancy.AspNetCore/RequestTenancyOptions.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/RequestTenancyOptions.cs
@@ -2,9 +2,15 @@
 
 namespace Ayaka.MultiTenancy.AspNetCore;
 
+using Ayaka.MultiTenancy.AspNetCore.Detection;
+
 /// <summary>
 ///     Represents the options to configure the behavior for the <see cref="RequestTenancyMiddleware"/>.
 /// </summary>
 public sealed class RequestTenancyOptions
 {
+    /// <summary>
+    ///     Gets the configured tenant detection strategies.
+    /// </summary>
+    public IList<ITenantDetectionStrategy> DetectionStrategies { get; init; } = [];
 }

--- a/src/Ayaka.MultiTenancy.AspNetCore/RequestTenancyOptions.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/RequestTenancyOptions.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore;
+
+/// <summary>
+///     Represents the options to configure the behavior for the <see cref="RequestTenancyMiddleware"/>.
+/// </summary>
+public sealed class RequestTenancyOptions
+{
+}

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/Ayaka.MultiTenancy.AspNetCore.Tests.csproj
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/Ayaka.MultiTenancy.AspNetCore.Tests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Ayaka.MultiTenancy.AspNetCore\Ayaka.MultiTenancy.AspNetCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/Ayaka.MultiTenancy.AspNetCore.Tests.csproj
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/Ayaka.MultiTenancy.AspNetCore.Tests.csproj
@@ -6,6 +6,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Ayaka.MultiTenancy.AspNetCore\Ayaka.MultiTenancy.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\Ayaka.MultiTenancy\Ayaka.MultiTenancy.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.13" />
   </ItemGroup>
 
 </Project>

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/DependencyInjection/ApplicationBuilderExtensionsTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/DependencyInjection/ApplicationBuilderExtensionsTest.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore.Tests.DependencyInjection;
+
+using Ayaka.MultiTenancy.DependencyInjection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+public sealed class ApplicationBuilderExtensionsTest
+{
+    [Fact]
+    public void Throws_InvalidOperationException_if_services_are_missing()
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder.UseTestServer();
+                webHostBuilder.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                });
+                webHostBuilder.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseMultiTenancy();
+                });
+            })
+            .Build();
+
+        var action = () => host.Start();
+
+        action
+            .Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage(
+                "Unable to find the required services. " +
+                "Please add all the required services by calling 'IServiceCollection.AddMultiTenancy()' in the application startup code.");
+    }
+}

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/DependencyInjection/MultiTenancyBuilderExtensionsTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/DependencyInjection/MultiTenancyBuilderExtensionsTest.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore.Tests.DependencyInjection;
+
+using Ayaka.MultiTenancy.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+public sealed class MultiTenancyBuilderExtensionsTest
+{
+    [Fact]
+    public void Does_return_same_instance_of_IMultiTenancyBuilder()
+    {
+        var builder = new TestMultiTenancyBuilder();
+
+        var result = builder.ConfigureRequestTenancy(_ => { });
+
+        result.Should().BeSameAs(builder);
+    }
+
+    [Fact]
+    public void Does_use_specified_IMultiTenancyBuilder_to_configure_request_tenancy()
+    {
+        var builder = new TestMultiTenancyBuilder();
+
+        builder.ConfigureRequestTenancy(requestTenancy =>
+        {
+            requestTenancy.MultiTenancy.Should().BeSameAs(builder);
+        });
+    }
+
+    private sealed class TestMultiTenancyBuilder : IMultiTenancyBuilder
+    {
+        public IServiceCollection Services { get; } = new ServiceCollection();
+    }
+}

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/DependencyInjection/RequestTenancyBuilderTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/DependencyInjection/RequestTenancyBuilderTest.cs
@@ -1,0 +1,164 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore.Tests.DependencyInjection;
+
+using Ayaka.MultiTenancy.AspNetCore.Detection;
+using Ayaka.MultiTenancy.DependencyInjection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+public sealed class RequestTenancyBuilderTest
+{
+    [Fact]
+    public void Does_add_options()
+    {
+        var builder = new TestMultiTenancyBuilder();
+
+        builder.ConfigureRequestTenancy(_ => { });
+
+        var sp = builder.Services.BuildServiceProvider();
+        var options = sp.GetService<IOptions<RequestTenancyOptions>>();
+
+        options.Should().NotBeNull("IOptions<RequestTenancyOptions> should be registered");
+    }
+
+    public sealed class DetectFromRequestHeader
+    {
+        [Fact]
+        public void Does_add_FromRequestHeaderStrategy()
+        {
+            var builder = new TestMultiTenancyBuilder();
+
+            builder.ConfigureRequestTenancy(opts => opts.DetectFromRequestHeader("foo"));
+
+            var sp = builder.Services.BuildServiceProvider();
+            var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
+
+            options.DetectionStrategies.Should().ContainSingle();
+
+            var strategy = options.DetectionStrategies[0];
+
+            strategy.Should().BeOfType<FromRequestHeaderStrategy>();
+            strategy.As<FromRequestHeaderStrategy>().HeaderName.Should().Be("foo");
+        }
+
+        [Fact]
+        public void Allows_multiple_to_be_added()
+        {
+            var builder = new TestMultiTenancyBuilder();
+
+            builder.ConfigureRequestTenancy(opts =>
+            {
+                opts.DetectFromRequestHeader("foo");
+                opts.DetectFromRequestHeader("bar");
+            });
+
+            var sp = builder.Services.BuildServiceProvider();
+            var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
+
+            options.DetectionStrategies.Should().HaveCount(2);
+            options.DetectionStrategies.Should().AllBeOfType<FromRequestHeaderStrategy>();
+
+            options.DetectionStrategies[0].As<FromRequestHeaderStrategy>().HeaderName.Should().Be("foo");
+            options.DetectionStrategies[1].As<FromRequestHeaderStrategy>().HeaderName.Should().Be("bar");
+        }
+    }
+
+    public sealed class DetectFromRequestHost
+    {
+        [Fact]
+        public void Does_add_FromRequestHostStrategy()
+        {
+            var builder = new TestMultiTenancyBuilder();
+
+            builder.ConfigureRequestTenancy(opts => opts.DetectFromRequestHost());
+
+            var sp = builder.Services.BuildServiceProvider();
+            var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
+
+            options.DetectionStrategies.Should().ContainSingle();
+            options.DetectionStrategies.Should().AllBeOfType<FromRequestHostStrategy>();
+        }
+    }
+
+    public sealed class DetectUsingType
+    {
+        [Fact]
+        public void Does_add_strategy()
+        {
+            var builder = new TestMultiTenancyBuilder();
+
+            builder.ConfigureRequestTenancy(opts => opts.DetectUsing<TestStrategy>());
+
+            var sp = builder.Services.BuildServiceProvider();
+            var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
+
+            options.DetectionStrategies.Should().ContainSingle();
+            options.DetectionStrategies.Should().AllBeOfType<TestStrategy>();
+        }
+
+        [Fact]
+        public void Does_resolve_dependencies_from_service_provider()
+        {
+            var builder = new TestMultiTenancyBuilder();
+
+            var service = new Dependency();
+            builder.Services.AddSingleton<IDependency>(service);
+
+            builder.ConfigureRequestTenancy(opts => opts.DetectUsing<TestStrategyWithDependency>());
+
+            var sp = builder.Services.BuildServiceProvider();
+            var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
+
+            options.DetectionStrategies.Should().ContainSingle();
+            options.DetectionStrategies.Should().AllBeOfType<TestStrategyWithDependency>();
+
+            options.DetectionStrategies[0].As<TestStrategyWithDependency>().Dependency.Should().BeSameAs(service);
+        }
+    }
+
+    public sealed class DetectUsingInstance
+    {
+        [Fact]
+        public void Does_add_strategy()
+        {
+            var builder = new TestMultiTenancyBuilder();
+
+            var strategy = new TestStrategy();
+            builder.ConfigureRequestTenancy(opts => opts.DetectUsing(strategy));
+
+            var sp = builder.Services.BuildServiceProvider();
+            var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
+
+            options.DetectionStrategies.Should().ContainSingle();
+            options.DetectionStrategies[0].Should().BeSameAs(strategy);
+        }
+    }
+
+    private sealed class TestMultiTenancyBuilder : IMultiTenancyBuilder
+    {
+        public IServiceCollection Services { get; } = new ServiceCollection();
+    }
+
+    private sealed class TestStrategy : ITenantDetectionStrategy
+    {
+        public Task<string?> TryDetectAsync(HttpContext context) => throw new NotImplementedException();
+    }
+
+    private sealed class TestStrategyWithDependency : ITenantDetectionStrategy
+    {
+        public TestStrategyWithDependency(IDependency dependency)
+        {
+            Dependency = dependency;
+        }
+
+        public IDependency Dependency { get; }
+
+        public Task<string?> TryDetectAsync(HttpContext context) => throw new NotImplementedException();
+    }
+
+    private interface IDependency;
+
+    private sealed class Dependency : IDependency;
+}

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/Detection/FromRequestHeaderStrategyTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/Detection/FromRequestHeaderStrategyTest.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore.Tests.Detection;
+
+using Ayaka.MultiTenancy.AspNetCore.Detection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+public sealed class FromRequestHeaderStrategyTest
+{
+    [Fact]
+    public void Getting_HeaderName_returns_the_header_name()
+    {
+        var actual = new FromRequestHeaderStrategy("X-Tenant-Id");
+
+        actual.HeaderName.Should().Be("X-Tenant-Id");
+    }
+
+    [Fact]
+    public async Task Does_return_null_when_no_header_is_available()
+    {
+        var httpRequest = A.Fake<HttpRequest>();
+        A.CallTo(() => httpRequest.Headers).Returns(new HeaderDictionary());
+
+        var httpContext = A.Fake<HttpContext>();
+        A.CallTo(() => httpContext.Request).Returns(httpRequest);
+
+        var actual = await new FromRequestHeaderStrategy("X-Tenant-Id").TryDetectAsync(httpContext);
+
+        actual.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task Does_return_null_when_header_has_empty_value(string? headerValue)
+    {
+        var httpRequest = A.Fake<HttpRequest>();
+        A.CallTo(() => httpRequest.Headers)
+            .Returns(
+                new HeaderDictionary(
+                    new Dictionary<string, StringValues>
+                    {
+                        { "X-Tenant-Id", headerValue }
+                    }));
+
+        var httpContext = A.Fake<HttpContext>();
+        A.CallTo(() => httpContext.Request).Returns(httpRequest);
+
+        var actual = await new FromRequestHeaderStrategy("X-Tenant-Id").TryDetectAsync(httpContext);
+
+        actual.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Does_return_header_value_as_tenant_identifier()
+    {
+        var httpRequest = A.Fake<HttpRequest>();
+        A.CallTo(() => httpRequest.Headers)
+            .Returns(
+                new HeaderDictionary(
+                    new Dictionary<string, StringValues>
+                    {
+                        { "X-Tenant-Id", "example" }
+                    }));
+
+        var httpContext = A.Fake<HttpContext>();
+        A.CallTo(() => httpContext.Request).Returns(httpRequest);
+
+        var actual = await new FromRequestHeaderStrategy("X-Tenant-Id").TryDetectAsync(httpContext);
+
+        actual.Should().Be("example");
+    }
+
+    [Fact]
+    public async Task Does_return_first_header_value_as_tenant_identifier_when_multiple_values_are_available()
+    {
+        var httpRequest = A.Fake<HttpRequest>();
+        A.CallTo(() => httpRequest.Headers)
+            .Returns(
+                new HeaderDictionary(
+                    new Dictionary<string, StringValues>
+                    {
+                        { "X-Tenant-Id", new StringValues(["example", "example2"]) }
+                    }));
+
+        var httpContext = A.Fake<HttpContext>();
+        A.CallTo(() => httpContext.Request).Returns(httpRequest);
+
+        var actual = await new FromRequestHeaderStrategy("X-Tenant-Id").TryDetectAsync(httpContext);
+
+        actual.Should().Be("example");
+    }
+}

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/Detection/FromRequestHostStrategyTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/Detection/FromRequestHostStrategyTest.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore.Tests.Detection;
+
+using Ayaka.MultiTenancy.AspNetCore.Detection;
+using Microsoft.AspNetCore.Http;
+
+public sealed class FromRequestHostStrategyTest
+{
+    [Fact]
+    public async Task Does_return_null_when_no_host_is_available()
+    {
+        var httpRequest = A.Fake<HttpRequest>();
+        A.CallTo(() => httpRequest.Host).Returns(new HostString(string.Empty));
+
+        var httpContext = A.Fake<HttpContext>();
+        A.CallTo(() => httpContext.Request).Returns(httpRequest);
+
+        var actual = await new FromRequestHostStrategy().TryDetectAsync(httpContext);
+
+        actual.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Does_return_null_when_host_has_insufficient_parts()
+    {
+        var httpRequest = A.Fake<HttpRequest>();
+        A.CallTo(() => httpRequest.Host).Returns(new HostString("localhost"));
+
+        var httpContext = A.Fake<HttpContext>();
+        A.CallTo(() => httpContext.Request).Returns(httpRequest);
+
+        var actual = await new FromRequestHostStrategy().TryDetectAsync(httpContext);
+
+        actual.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("example.com", "example")]
+    [InlineData("sub.example.com", "sub")]
+    [InlineData("deep-sub.sub.example.com", "deep-sub")]
+    public async Task Does_return_left_most_part_as_tenant_identifier(string hostValue, string expectedTenantId)
+    {
+        var httpRequest = A.Fake<HttpRequest>();
+        A.CallTo(() => httpRequest.Host).Returns(new HostString(hostValue));
+
+        var httpContext = A.Fake<HttpContext>();
+        A.CallTo(() => httpContext.Request).Returns(httpRequest);
+
+        var actual = await new FromRequestHostStrategy().TryDetectAsync(httpContext);
+
+        actual.Should().Be(expectedTenantId);
+    }
+}

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/Internal/MvcBuilderExtensions.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/Internal/MvcBuilderExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore.Tests.Internal;
+
+using Microsoft.Extensions.DependencyInjection;
+
+internal static class MvcBuilderExtensions
+{
+    /// <summary>
+    ///     Adds the specified <paramref name="controllerTypes"/> to the available controllers.
+    /// </summary>
+    /// <remarks>
+    ///     By default, ASP.NET Core does not recognize controllers that are private or nested inside another class.
+    ///     This method allows adding controllers made for specific test cases to the available controllers.
+    /// </remarks>
+    /// <param name="mvcBuilder">The <see cref="IMvcBuilder"/> to add the controllers to.</param>
+    /// <param name="controllerTypes">The controller types to add.</param>
+    /// <returns>The same <see cref="IMvcBuilder"/>.</returns>
+    public static IMvcBuilder AddTestControllers(this IMvcBuilder mvcBuilder, params Type[] controllerTypes)
+    {
+        mvcBuilder
+            .PartManager
+            .FeatureProviders
+            .Add(new TestControllerFeatureProvider(controllerTypes));
+
+        return mvcBuilder;
+    }
+}

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/Internal/TestControllerFeatureProvider.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/Internal/TestControllerFeatureProvider.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore.Tests.Internal;
+
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Controllers;
+
+internal sealed class TestControllerFeatureProvider : IApplicationFeatureProvider<ControllerFeature>
+{
+    private readonly Type[] _controllerTypes;
+
+    public TestControllerFeatureProvider(Type[] controllerTypes)
+    {
+        _controllerTypes = controllerTypes;
+    }
+
+    public void PopulateFeature(IEnumerable<ApplicationPart> parts, ControllerFeature feature)
+    {
+        foreach (var controllerType in _controllerTypes)
+        {
+            feature.Controllers.Add(controllerType.GetTypeInfo());
+        }
+    }
+}

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/RequestTenancyMiddlewareTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/RequestTenancyMiddlewareTest.cs
@@ -54,6 +54,31 @@ public sealed class RequestTenancyMiddlewareTest
             .WithMessage("Tenant was already set previously in the request pipeline");
     }
 
+    [Fact]
+    public async Task Throws_if_no_tenant_detection_strategies_are_configured()
+    {
+        using var host = await CreateHost(
+            services =>
+            {
+                services
+                    .AddMultiTenancy()
+                    .ConfigureRequestTenancy(_ => { });
+            },
+            app =>
+            {
+                app.UseMultiTenancy();
+            });
+
+        using var client = host.GetTestClient();
+
+        var action = () => client.GetAsync("/tenant");
+
+        await action
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("No tenant detection strategies are configured");
+    }
+
     public sealed class WhenUsingEndpoints
     {
         [Fact]

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/RequestTenancyMiddlewareTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/RequestTenancyMiddlewareTest.cs
@@ -1,0 +1,323 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore.Tests;
+
+using Ayaka.MultiTenancy.AspNetCore.Detection;
+using Ayaka.MultiTenancy.AspNetCore.Tests.Internal;
+using Ayaka.MultiTenancy.DependencyInjection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+public sealed class RequestTenancyMiddlewareTest
+{
+    public sealed class WhenUsingEndpoints
+    {
+        [Fact]
+        public async Task Does_set_tenant_context_if_tenant_is_detected()
+        {
+            using var host = await CreateHost(
+                services =>
+                {
+                    services
+                        .AddMultiTenancy()
+                        .ConfigureRequestTenancy(requestTenancy =>
+                        {
+                            requestTenancy.DetectUsing(new StaticValueStrategy("test"));
+                        });
+                },
+                app =>
+                {
+                    app.UseMultiTenancy();
+
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapGet("/tenant", GetTenantId);
+                    });
+                });
+
+            using var client = host.GetTestClient();
+            using var response = await client.GetAsync("/tenant");
+            var content = await response.Content.ReadAsStringAsync();
+
+            content.Should().Be("test", "because the tenant id should be set");
+
+            return;
+
+            static IResult GetTenantId([FromServices] ITenantContextAccessor accessor)
+                => TypedResults.Content(accessor.TenantContext?.Id ?? "no tenant");
+        }
+
+        [Fact]
+        public async Task Does_skip_detection_if_endpoint_disables_detection()
+        {
+            using var host = await CreateHost(
+                services =>
+                {
+                    services
+                        .AddMultiTenancy()
+                        .ConfigureRequestTenancy(requestTenancy =>
+                        {
+                            requestTenancy.DetectUsing(new StaticValueStrategy("test"));
+                        });
+                },
+                app =>
+                {
+                    app.UseMultiTenancy();
+
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapGet("/tenant", GetTenantId);
+                    });
+                });
+
+            using var client = host.GetTestClient();
+            using var response = await client.GetAsync("/tenant");
+            var content = await response.Content.ReadAsStringAsync();
+
+            content.Should().Be("no tenant", "because the tenant id should not be set");
+
+            return;
+
+            [DisableMultiTenancy]
+            static IResult GetTenantId([FromServices] ITenantContextAccessor accessor)
+                => TypedResults.Content(accessor.TenantContext?.Id ?? "no tenant");
+        }
+
+        [Fact]
+        public async Task Does_consume_all_available_detection_strategies()
+        {
+            using var host = await CreateHost(
+                services =>
+                {
+                    services
+                        .AddMultiTenancy()
+                        .ConfigureRequestTenancy(requestTenancy =>
+                        {
+                            requestTenancy
+                                .DetectUsing(new StaticValueStrategy(null))
+                                .DetectUsing(new StaticValueStrategy("test"));
+                        });
+                },
+                app =>
+                {
+                    app.UseMultiTenancy();
+
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapGet("/tenant", GetTenantId);
+                    });
+                });
+
+            using var client = host.GetTestClient();
+            using var response = await client.GetAsync("/tenant");
+            var content = await response.Content.ReadAsStringAsync();
+
+            content.Should().Be("test", "because the tenant id should be set");
+
+            return;
+
+            static IResult GetTenantId([FromServices] ITenantContextAccessor accessor)
+                => TypedResults.Content(accessor.TenantContext?.Id ?? "no tenant");
+        }
+    }
+
+    public sealed class WhenUsingControllers
+    {
+        [Fact]
+        public async Task Does_set_tenant_context_if_tenant_is_detected()
+        {
+            using var host = await CreateHost(
+                services =>
+                {
+                    services
+                        .AddControllers()
+                        .AddTestControllers(typeof(TestController));
+
+                    services
+                        .AddMultiTenancy()
+                        .ConfigureRequestTenancy(requestTenancy =>
+                        {
+                            requestTenancy.DetectUsing(new StaticValueStrategy("test"));
+                        });
+                },
+                app =>
+                {
+                    app.UseMultiTenancy();
+
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapControllers();
+                    });
+                });
+
+            using var client = host.GetTestClient();
+            using var response = await client.GetAsync("/tenancy-enabled");
+            var content = await response.Content.ReadAsStringAsync();
+
+            content.Should().Be("test", "because the tenant id should be set");
+        }
+
+        [Fact]
+        public async Task Does_skip_detection_if_action_disables_detection()
+        {
+            using var host = await CreateHost(
+                services =>
+                {
+                    services
+                        .AddControllers()
+                        .AddTestControllers(typeof(TestController));
+
+                    services
+                        .AddMultiTenancy()
+                        .ConfigureRequestTenancy(requestTenancy =>
+                        {
+                            requestTenancy.DetectUsing(new StaticValueStrategy("test"));
+                        });
+                },
+                app =>
+                {
+                    app.UseMultiTenancy();
+
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapControllers();
+                    });
+                });
+
+            using var client = host.GetTestClient();
+            using var response = await client.GetAsync("/tenancy-disabled");
+            var content = await response.Content.ReadAsStringAsync();
+
+            content.Should().Be("no tenant", "because the tenant id should not be set");
+        }
+
+        [Fact]
+        public async Task Does_skip_detection_if_controller_disables_detection()
+        {
+            using var host = await CreateHost(
+                services =>
+                {
+                    services
+                        .AddControllers()
+                        .AddTestControllers(typeof(InheritanceTestController));
+
+                    services
+                        .AddMultiTenancy()
+                        .ConfigureRequestTenancy(requestTenancy =>
+                        {
+                            requestTenancy.DetectUsing(new StaticValueStrategy("test"));
+                        });
+                },
+                app =>
+                {
+                    app.UseMultiTenancy();
+
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapControllers();
+                    });
+                });
+
+            using var client = host.GetTestClient();
+            using var response = await client.GetAsync("/inherited-tenancy-disabled");
+            var content = await response.Content.ReadAsStringAsync();
+
+            content.Should().Be("no tenant", "because the tenant id should not be set");
+        }
+
+        [Fact]
+        public async Task Does_consume_all_available_detection_strategies()
+        {
+            using var host = await CreateHost(
+                services =>
+                {
+                    services
+                        .AddControllers()
+                        .AddTestControllers(typeof(TestController));
+
+                    services
+                        .AddMultiTenancy()
+                        .ConfigureRequestTenancy(requestTenancy =>
+                        {
+                            requestTenancy
+                                .DetectUsing(new StaticValueStrategy(null))
+                                .DetectUsing(new StaticValueStrategy("test"));
+                        });
+                },
+                app =>
+                {
+                    app.UseMultiTenancy();
+
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapControllers();
+                    });
+                });
+
+            using var client = host.GetTestClient();
+            using var response = await client.GetAsync("/tenancy-enabled");
+            var content = await response.Content.ReadAsStringAsync();
+
+            content.Should().Be("test", "because the tenant id should be set");
+
+            return;
+        }
+
+        private sealed class TestController : ControllerBase
+        {
+            [HttpGet("/tenancy-enabled")]
+            public IActionResult GetTenantId([FromServices] ITenantContextAccessor accessor)
+                => Ok(accessor.TenantContext?.Id ?? "no tenant");
+
+            [DisableMultiTenancy]
+            [HttpGet("/tenancy-disabled")]
+            public IActionResult GetTenantIdDisabled([FromServices] ITenantContextAccessor accessor)
+                => Ok(accessor.TenantContext?.Id ?? "no tenant");
+        }
+
+        [DisableMultiTenancy]
+        private sealed class InheritanceTestController : ControllerBase
+        {
+            [HttpGet("/inherited-tenancy-disabled")]
+            public IActionResult GetTenantId([FromServices] ITenantContextAccessor accessor)
+                => Ok(accessor.TenantContext?.Id ?? "no tenant");
+        }
+    }
+
+    private static Task<IHost> CreateHost(
+        Action<IServiceCollection> configureServices,
+        Action<IApplicationBuilder> configureApp)
+        => new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder.UseTestServer();
+                webHostBuilder.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    configureServices(services);
+                });
+                webHostBuilder.Configure(app =>
+                {
+                    app.UseRouting();
+                    configureApp(app);
+                });
+            })
+            .StartAsync();
+
+    private sealed class StaticValueStrategy : ITenantDetectionStrategy
+    {
+        private readonly string? _tenantId;
+
+        public StaticValueStrategy(string? tenantId)
+        {
+            _tenantId = tenantId;
+        }
+
+        public Task<string?> TryDetectAsync(HttpContext context) => Task.FromResult(_tenantId);
+    }
+}

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/RequestTenancyMiddlewareTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/RequestTenancyMiddlewareTest.cs
@@ -42,11 +42,16 @@ public sealed class RequestTenancyMiddlewareTest
                 });
 
                 app.UseMultiTenancy();
+
+                app.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapGet("/", context => Task.CompletedTask);
+                });
             });
 
         using var client = host.GetTestClient();
 
-        var action = () => client.GetAsync("/tenant");
+        var action = () => client.GetAsync("/");
 
         await action
             .Should()
@@ -67,11 +72,16 @@ public sealed class RequestTenancyMiddlewareTest
             app =>
             {
                 app.UseMultiTenancy();
+
+                app.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapGet("/", context => Task.CompletedTask);
+                });
             });
 
         using var client = host.GetTestClient();
 
-        var action = () => client.GetAsync("/tenant");
+        var action = () => client.GetAsync("/");
 
         await action
             .Should()


### PR DESCRIPTION
## Description

Introduces a new `Ayaka.MultiTenancy.AspNetCore` package that provides a middleware which can detect the tenant from a request.

Currently supports request host and request headers.

Partially Resolves #149 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Various unit tests for each newly introduced component.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
