### PR TITLE
fix: null reference exception in GitHub release target

### DIFF
--- a/src/Ayaka.Nuke/GitHub/GitHubReleaseSettings.cs
+++ b/src/Ayaka.Nuke/GitHub/GitHubReleaseSettings.cs
@@ -62,5 +62,5 @@ public class GitHubReleaseSettings : GitHubSettings
     /// <summary>
     ///     Gets the optional artifact paths to upload to the release.
     /// </summary>
-    public IReadOnlyList<string> ArtifactPaths => Get<List<string>>(() => ArtifactPaths);
+    public IReadOnlyList<string>? ArtifactPaths => Get<List<string>?>(() => ArtifactPaths);
 }

--- a/src/Ayaka.Nuke/GitHub/GitHubTasks.cs
+++ b/src/Ayaka.Nuke/GitHub/GitHubTasks.cs
@@ -66,7 +66,7 @@ public static class GitHubTasks
         Log.Verbose("  Draft: {Draft}", release.Draft);
         Log.Verbose("  Pre-release: {PreRelease}", release.Prerelease);
 
-        if (settings.ArtifactPaths.Count > 0)
+        if (settings.ArtifactPaths is { Count: > 0 })
         {
             Log.Debug("Uploading {ArtifactCount} artifact(s) to release...", settings.ArtifactPaths.Count);
 

--- a/src/Ayaka.Nuke/PublicAPI.Shipped.txt
+++ b/src/Ayaka.Nuke/PublicAPI.Shipped.txt
@@ -70,7 +70,6 @@ Ayaka.Nuke.GitHub.GitHubReleaseNotesSettings.Tag.get -> string!
 Ayaka.Nuke.GitHub.GitHubReleaseNotesSettings.TargetCommitish.get -> string?
 Ayaka.Nuke.GitHub.GitHubReleaseNotesSettingsExtensions
 Ayaka.Nuke.GitHub.GitHubReleaseSettings
-Ayaka.Nuke.GitHub.GitHubReleaseSettings.ArtifactPaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Ayaka.Nuke.GitHub.GitHubReleaseSettings.Body.get -> string?
 Ayaka.Nuke.GitHub.GitHubReleaseSettings.Draft.get -> bool?
 Ayaka.Nuke.GitHub.GitHubReleaseSettings.GenerateReleaseNotes.get -> bool?

--- a/src/Ayaka.Nuke/PublicAPI.Unshipped.txt
+++ b/src/Ayaka.Nuke/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿#nullable enable
+Ayaka.Nuke.GitHub.GitHubReleaseSettings.ArtifactPaths.get -> System.Collections.Generic.IReadOnlyList<string!>?


### PR DESCRIPTION
## Description

Fixes a bug in the GitHub release target.
Due to wrong nullability declaration, a `NullReferenceException` will always happen when running the target.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

None

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
