### PR TITLE
feat: add tenant tag to current request's activity

### DIFF
--- a/src/Ayaka.MultiTenancy.AspNetCore/DependencyInjection/RequestTenancyBuilder.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/DependencyInjection/RequestTenancyBuilder.cs
@@ -2,6 +2,7 @@
 
 namespace Ayaka.MultiTenancy.DependencyInjection;
 
+using System.Diagnostics;
 using Ayaka.MultiTenancy.AspNetCore;
 using Ayaka.MultiTenancy.AspNetCore.Detection;
 using Microsoft.Extensions.DependencyInjection;
@@ -84,6 +85,21 @@ public sealed class RequestTenancyBuilder
     /// <returns>The same <see cref="RequestTenancyBuilder"/>.</returns>
     public RequestTenancyBuilder DetectUsing(ITenantDetectionStrategy strategy)
         => AddStrategy(_ => strategy);
+
+
+    /// <summary>
+    ///     Configures the request tenancy to use the specified <paramref name="tagName"/> as the name of the tag
+    ///     written to the request's <see cref="Activity"/> after the middleware successfully detected a tenant.
+    /// </summary>
+    /// <param name="tagName">The name of the tag to write to the request's <see cref="Activity"/>.</param>
+    /// <returns>The same <see cref="RequestTenancyBuilder"/>.</returns>
+    public RequestTenancyBuilder UseCustomActivityTagName(string tagName)
+    {
+        _configureActions.Add(
+            (options, _) => options.ActivityTagName = tagName);
+
+        return this;
+    }
 
     internal void ConfigureServices()
     {

--- a/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Unshipped.txt
+++ b/src/Ayaka.MultiTenancy.AspNetCore/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 ﻿#nullable enable
+Ayaka.MultiTenancy.AspNetCore.RequestTenancyOptions.ActivityTagName.get -> string!
+Ayaka.MultiTenancy.AspNetCore.RequestTenancyOptions.ActivityTagName.set -> void
+Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder.UseCustomActivityTagName(string! tagName) -> Ayaka.MultiTenancy.DependencyInjection.RequestTenancyBuilder!

--- a/src/Ayaka.MultiTenancy.AspNetCore/RequestTenancyMiddleware.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/RequestTenancyMiddleware.cs
@@ -3,6 +3,7 @@
 namespace Ayaka.MultiTenancy.AspNetCore;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -69,6 +70,12 @@ public sealed partial class RequestTenancyMiddleware
         var tenant = await TryDetectTenant(context);
         if (tenant is not null)
         {
+            var activityFeature = context.Features.Get<IHttpActivityFeature>();
+            if (activityFeature is not null)
+            {
+                _ = activityFeature.Activity.SetTag(_options.ActivityTagName, tenant);
+            }
+
             _accessor.TenantContext = new TenantContext(tenant, tenant);
         }
 

--- a/src/Ayaka.MultiTenancy.AspNetCore/RequestTenancyOptions.cs
+++ b/src/Ayaka.MultiTenancy.AspNetCore/RequestTenancyOptions.cs
@@ -2,7 +2,9 @@
 
 namespace Ayaka.MultiTenancy.AspNetCore;
 
+using System.Diagnostics;
 using Ayaka.MultiTenancy.AspNetCore.Detection;
+using Microsoft.AspNetCore.Http.Features;
 
 /// <summary>
 ///     Represents the options to configure the behavior for the <see cref="RequestTenancyMiddleware"/>.
@@ -13,4 +15,14 @@ public sealed class RequestTenancyOptions
     ///     Gets the configured tenant detection strategies.
     /// </summary>
     public IList<ITenantDetectionStrategy> DetectionStrategies { get; init; } = [];
+
+    /// <summary>
+    ///     Gets or sets the name of the tag written to the request's <see cref="Activity"/> after the middleware
+    ///     successfully detected a tenant.
+    /// </summary>
+    /// <remarks>
+    ///     The tag is only written if the <see cref="IHttpActivityFeature"/> is available. It does not use
+    ///     <see cref="Activity.Current"/>.
+    /// </remarks>
+    public string ActivityTagName { get; set; } = "tenant";
 }

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/DependencyInjection/RequestTenancyBuilderTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/DependencyInjection/RequestTenancyBuilderTest.cs
@@ -136,6 +136,35 @@ public sealed class RequestTenancyBuilderTest
         }
     }
 
+    public sealed class ActivityTagName
+    {
+        [Fact]
+        public void Does_have_default_activity_tag_name()
+        {
+            var builder = new TestMultiTenancyBuilder();
+
+            builder.ConfigureRequestTenancy(opts => { });
+
+            var sp = builder.Services.BuildServiceProvider();
+            var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
+
+            options.ActivityTagName.Should().Be("tenant");
+        }
+
+        [Fact]
+        public void Does_set_activity_tag_name()
+        {
+            var builder = new TestMultiTenancyBuilder();
+
+            builder.ConfigureRequestTenancy(opts => opts.UseCustomActivityTagName("custom"));
+
+            var sp = builder.Services.BuildServiceProvider();
+            var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
+
+            options.ActivityTagName.Should().Be("custom");
+        }
+    }
+
     private sealed class TestMultiTenancyBuilder : IMultiTenancyBuilder
     {
         public IServiceCollection Services { get; } = new ServiceCollection();

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/Internal/ActivityTracker.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/Internal/ActivityTracker.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Raphael Strotz. All rights reserved.
+
+namespace Ayaka.MultiTenancy.AspNetCore.Tests.Internal;
+
+using System.Diagnostics;
+
+internal sealed class ActivityTracker : IDisposable
+{
+    private readonly List<Activity> _startedActivities = [];
+    private readonly List<Activity> _stoppedActivities = [];
+
+    public ActivityTracker()
+    {
+        Source = new ActivitySource(Path.GetRandomFileName());
+
+        Listener = new ActivityListener
+        {
+            ShouldListenTo = s => ReferenceEquals(s, Source),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = a => _startedActivities.Add(a),
+            ActivityStopped = a => _stoppedActivities.Add(a)
+        };
+
+        ActivitySource.AddActivityListener(Listener);
+    }
+
+    public ActivitySource Source { get; }
+
+    public ActivityListener Listener { get; }
+
+    public IReadOnlyList<Activity> StartedActivities => _startedActivities;
+
+    public IReadOnlyList<Activity> StoppedActivities => _stoppedActivities;
+
+    public void Dispose()
+    {
+        Source.Dispose();
+        Listener.Dispose();
+    }
+}


### PR DESCRIPTION
## Description

The `RequestTenancyMiddleware` will now add a tag to the current request's `Activity` containing the detected tenant ID.
By default, the tag name is `tenant`. But it's possible to change the name of the tag using

```
.ConfigureRequestTenancy(builder => 
{
    builder.UseCustomActivityTagName("custom");
});
```

Please note that the middleware uses `IHttpActivityFeature` instead of `Activity.Current` since the `Activity.Current` does not necessarily represent the activity of the request itself but some activity of another middleware or filter.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Unit tests for builder extension and the activity tagging in the middleware

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
