### PR TITLE
chore(deps): update GitVersion.Tool to 6.7.0

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,15 +1,15 @@
-mode: ContinuousDeployment
+mode: ContinuousDelivery
 assembly-versioning-scheme: MajorMinorPatch
 major-version-bump-message: "^(chore|docs|feat|fix|refactor|revert|style|test)(\\([\\w\\s-]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
 minor-version-bump-message: "^(feat)(\\([\\w\\s-]*\\))?:"
 patch-version-bump-message: "^(chore|docs|fix|refactor|revert|style|test)(\\([\\w\\s-]*\\))?:"
 branches:
   main:
-    mode: ContinuousDeployment
-    tag: preview
+    mode: ContinuousDelivery
+    label: preview
   pull-request:
-    mode: ContinuousDeployment
-    tag: pr
+    mode: ContinuousDelivery
+    label: pr
     source-branches:
       - main
       - feature

--- a/nukebuild/Build.csproj
+++ b/nukebuild/Build.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageDownload Include="dotnet-validate" Version="[0.0.1-preview.304]" />
-    <PackageDownload Include="GitVersion.Tool" Version="[5.12.0]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[6.7.0]" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Migrate GitVersion.yml to the v6 configuration schema:

- Rename `tag` → `label` (renamed in GitVersion v6.0.0).
- Rename `mode: ContinuousDeployment` → `mode: ContinuousDelivery`. In v6 the deployment-mode names shifted: v5's `ContinuousDeployment` (append a build counter such as `-preview.23`) is now spelled `ContinuousDelivery`, and v6's new `ContinuousDeployment` mode has different semantics.

Without these renames, v6.7.0 silently dropped the `preview` label and the build counter, producing e.g. `Ayaka.Nuke.2.2.1.nupkg` instead of `Ayaka.Nuke.2.2.1-preview.23.nupkg`.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Local execution and reviewing the numbers generated in workflows.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
