### PR TITLE
chore: improve how AI can commit and name PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,8 +48,12 @@ See `AGENTS.md` at the repo root for the full agent guide.
 
 ## Commits & PRs
 
-- Conventional commits and PR titles; types: `chore`, `docs`, `feat`, `fix`, `refactor`, `revert`,
-  `style`, `test`
+- Conventional commits and PR titles, validated against `.github/semantic.yml` — a non-matching type
+  fails the PR check
+- Allowed types are a closed set, exactly these, nothing else: `chore`, `docs`, `feat`, `fix`,
+  `refactor`, `revert`, `style`, `test`
+- `ci`, `build`, and `perf` are **not** enabled — use `chore` for CI/workflow, build, tooling, and
+  dependency changes
 - Version bump: `feat:` → minor, everything else → patch, `!` or `BREAKING CHANGE:` footer → major
 - PR labels drive the changelog: `breaking-change`, `enhancement`, `bug`, `dependencies`,
   `documentation`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,9 +109,12 @@ xunit + FluentAssertions + FakeItEasy (see `eng/Packages.props` for versions).
 
 ## Commits, PRs, releases
 
-- **Conventional commits** — enforced on PR titles (`.github/semantic.yml`) and used by GitVersion
-  for versioning
-- Allowed types: `chore`, `docs`, `feat`, `fix`, `refactor`, `revert`, `style`, `test` — optional `(scope)`
+- **Conventional commits** — PR titles are validated against `.github/semantic.yml`, so a
+  non-matching type fails the PR check; GitVersion also derives the version from them
+- Allowed types are a **closed set — exactly these, nothing else**: `chore`, `docs`, `feat`, `fix`,
+  `refactor`, `revert`, `style`, `test` (optional `(scope)`)
+- The standard Conventional Commits types `ci`, `build`, and `perf` are **not** enabled here — use
+  `chore` for CI/workflow, build, tooling, and dependency changes
 - Version bump: `feat:` → minor, everything else → patch, `!` or `BREAKING CHANGE:` footer → major
 - Changelog sections come from **PR labels**: `breaking-change`, `enhancement`, `bug`, `dependencies`,
   `documentation`


### PR DESCRIPTION
This pull request updates the documentation to clarify and enforce the project's conventional commit and PR title requirements. The changes emphasize that only a specific set of commit types is allowed, with validation enforced via `.github/semantic.yml`, and that certain standard types are intentionally excluded.

Commit and PR conventions:

* Commit and PR titles are now strictly validated against `.github/semantic.yml`; only the following types are allowed: `chore`, `docs`, `feat`, `fix`, `refactor`, `revert`, `style`, `test`. Any non-matching type will fail the PR check. (`.github/copilot-instructions.md`, `AGENTS.md`) [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L51-R56) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L112-R117)
* The standard Conventional Commits types `ci`, `build`, and `perf` are explicitly not enabled; contributors should use `chore` for CI, build, tooling, and dependency changes. (`.github/copilot-instructions.md`, `AGENTS.md`) [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L51-R56) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L112-R117)