### PR TITLE
chore: bump CI Node.js from LTS 20 (iron) to LTS 24 (krypton)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 'lts/iron'
+          node-version: 'lts/krypton'
 
       - name: NuGet Cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5


### PR DESCRIPTION
This pull request updates the Node.js version used in the CI workflow to ensure compatibility with the latest long-term support release.

CI workflow update:

* Updated the Node.js version in the `.github/workflows/ci.yml` workflow from `lts/iron` to `lts/krypton` to use the newest LTS version.