### PR TITLE
chore: bump dotnet-validate to net10 build, drop net6 SDK install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,6 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
-        with:
-          dotnet-version: 6.x # Required for dotnet-validate
-          global-json-file: ./global.json # Required, otherwise only the versions above get installed
 
       - name: Restore .NET Tools
         run: |

--- a/docs/en/guide/packages/nuke/build-components/dotnet.md
+++ b/docs/en/guide/packages/nuke/build-components/dotnet.md
@@ -494,10 +494,12 @@ See [Executing CLI Tools] for more information.
 :::
 
 ::: warning
-Please note that `dotnet-validate` with version `0.0.1-preview.304` and below still requires .NET 6 SDK installed
-on the build system.
+`dotnet-validate` runs on the .NET runtime it was built against, which depends on its version:
+`0.0.1-preview.304` and below target .NET 6, `0.0.1-preview.537` targets .NET 8, and
+`0.0.1-preview.582` and above target .NET 10.
 
-Since the support for .NET 6 ended in Nov 2024, you likely have to install it manually.
+Make sure the matching .NET SDK (or runtime) is installed on your build system. Picking a version that
+targets the same .NET as your build avoids having to install an extra runtime just for this tool.
 :::
 
 By default, `NuGetPackagesToPush` represents all packages (`*.nupkg`) within the `PackagesDirectory` directory of the

--- a/nukebuild/Build.csproj
+++ b/nukebuild/Build.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="dotnet-validate" Version="[0.0.1-preview.304]" />
+    <PackageDownload Include="dotnet-validate" Version="[0.0.1-preview.582]" />
     <PackageDownload Include="GitVersion.Tool" Version="[6.7.0]" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description

Bump `dotnet-validate` from `0.0.1-preview.304` to `0.0.1-preview.582`, which ships a `net10.0` tool instead of `net6.0`. The repo's `net10` SDK (`global.json`) now provides the runtime it needs, so the dedicated 6.x SDK install in CI is obsolete and removed. 

Docs warning updated to map versions to runtimes.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Workflows

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
