### PR TITLE
feat!: target net10

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "nuke.globaltool": {
-      "version": "9.0.4",
+      "version": "10.1.0",
       "commands": [
         "nuke"
       ],

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@
 Ayaka is a collection of NuGet packages helping with .NET application development.
 
 `src/` contains the package projects, mirrored by `test/<Project>.Tests` xunit projects (not every
-package has one). Everything targets net9.0 only; the SDK is pinned to 9.0.300 in `global.json`.
+package has one). Everything targets net10.0 only; the SDK is pinned to 10.0.301 in `global.json`.
 
 See `AGENTS.md` at the repo root for the full agent guide.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ MIT licensed, docs at <https://xzelsius.github.io/Ayaka>.
 | `Ayaka.MultiTenancy`              | `src/Ayaka.MultiTenancy`              | preview                                                                                                                                         |
 | `Ayaka.MultiTenancy.AspNetCore`   | `src/Ayaka.MultiTenancy.AspNetCore`   | preview                                                                                                                                         |
 
-Everything targets **net9.0 only** — no multi-targeting, by explicit decision. The .NET SDK is pinned
-to `9.0.300` in `global.json`.
+Everything targets **net10.0 only** — no multi-targeting, by explicit decision. The .NET SDK is pinned
+to `10.0.301` in `global.json`.
 
 ## Repository map
 

--- a/eng/TargetFramework.props
+++ b/eng/TargetFramework.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <DotNetTargetFramework>net9.0</DotNetTargetFramework>
+    <DotNetTargetFramework>net10.0</DotNetTargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/nukebuild/Build.csproj
+++ b/nukebuild/Build.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="9.0.4" />
+    <PackageReference Include="Nuke.Common" Version="10.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ayaka.MultiTenancy.Abstractions/Ayaka.MultiTenancy.Abstractions.csproj
+++ b/src/Ayaka.MultiTenancy.Abstractions/Ayaka.MultiTenancy.Abstractions.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/Ayaka.Nuke/Ayaka.Nuke.csproj
+++ b/src/Ayaka.Nuke/Ayaka.Nuke.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="9.0.4" />
+    <PackageReference Include="Nuke.Common" Version="10.1.0" />
     <PackageReference Include="Octokit" Version="14.0.0" />
   </ItemGroup>
 

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/Ayaka.MultiTenancy.AspNetCore.Tests.csproj
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/Ayaka.MultiTenancy.AspNetCore.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="FastEndpoints" Version="6.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/test/Ayaka.MultiTenancy.Tests/Ayaka.MultiTenancy.Tests.csproj
+++ b/test/Ayaka.MultiTenancy.Tests/Ayaka.MultiTenancy.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Retarget all projects from net9.0 to net10.0 and move the dependencies that track the runtime accordingly:

- TFM net9.0 -> net10.0 (eng/TargetFramework.props, cascades to all projects)
- Nuke.Common + Nuke global tool 9.0.4 -> 10.1.0 (NUKE v9 caps at net9)
- Microsoft.Extensions.DependencyInjection[.Abstractions] 9.0.5 -> 10.0.9
- Microsoft.AspNetCore.TestHost 9.0.5 -> 10.0.9
- Docs (AGENTS.md, copilot-instructions.md): net9.0/9.0.300 -> net10.0/10.0.301

Note: NuGet restore now surfaces CVEs that will be fixed outside of this PR.

### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Workflows

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
