### PR TITLE
chore(deps): replace FluentAssertions with Shouldly

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -9,6 +9,10 @@ The full guide is in `AGENTS.md` (always loaded); this file only adds test-speci
 
 - Use `[Fact]`, or `[Theory]` + `[InlineData]` for parameterized cases
 - Pass `TestContext.Current.CancellationToken` to methods that accept a `CancellationToken` — the xUnit1051 analyzer flags calls that omit it
+- Assert with Shouldly: `actual.ShouldBe(expected)`, `actual.ShouldNotBeNull()`, `actual.ShouldBeOfType<T>()`, collections via `ShouldHaveSingleItem()` / `ShouldContain(...)`
+- `ShouldHaveSingleItem()` and `ShouldBeOfType<T>()` return the (typed) value — chain on it instead of re-indexing or casting
+- Deep structural equivalence: `actual.ShouldBeEquivalentTo(expected)` — use where record equality is wrong because a member (e.g. an `ImmutableDictionary`) compares by reference
+- Exception assertions use Shouldly's static form: `await Should.ThrowAsync<T>(act)` / `Should.Throw<T>(action)` (the delegate is the argument, not the receiver)
 - Fakes: `A.Fake<T>()` to create, `A.CallTo(() => ...)` to configure and assert (FakeItEasy)
 - Internals can be made testable via `InternalsVisibleTo` in the src `.csproj` (already declared
   for `Ayaka.Nuke` and `Ayaka.MultiTenancy`)

--- a/.editorconfig
+++ b/.editorconfig
@@ -372,5 +372,5 @@ resharper_arguments_literal = named
 
 [/test/**/*.cs]
 # Computed value is never used
-# Reason: We don't want this rule in tests as would not play nice with FluentAssertions
+# Reason: We don't want this rule in tests as it would not play nice with the assertion library (Shouldly)
 dotnet_diagnostic.IDE0058.severity = none

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,7 +42,7 @@ See `AGENTS.md` at the repo root for the full agent guide.
 
 ## Tests
 
-- xunit + FluentAssertions + FakeItEasy via global usings (don't add `using Xunit;`)
+- xunit + Shouldly + FakeItEasy via global usings (don't add `using Xunit;`)
 - Class `<TypeName>Test`, snake_case sentence method names
 - Group related cases in nested classes named for the member/scenario under test
 

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -8,7 +8,7 @@ applyTo: "test/**/*.cs"
 
 Frameworks & layout:
 
-- xunit + FluentAssertions + FakeItEasy — all available via global usings (no `using Xunit;` etc.
+- xunit + Shouldly + FakeItEasy — all available via global usings (no `using Xunit;` etc.
   needed); versions are managed centrally in `eng/Packages.props`
 - Test projects live in `test/<Project>.Tests` (not every package has one); namespaces mirror the
   source project with a `.Tests` suffix
@@ -26,7 +26,14 @@ Writing tests:
 
 - Use `[Fact]`, or `[Theory]` + `[InlineData]` for parameterized cases
 - Pass `TestContext.Current.CancellationToken` to methods that accept a `CancellationToken` (the xUnit1051 analyzer flags calls that omit it)
-- Assert with FluentAssertions (`result.Should().BeSameAs(expected)`)
+- Assert with Shouldly (`result.ShouldBeSameAs(expected)`); collections via `ShouldHaveSingleItem()` /
+  `ShouldContain(...)`
+- `ShouldHaveSingleItem()` and `ShouldBeOfType<T>()` return the (typed) value — chain on it instead
+  of re-indexing or casting
+- Deep structural equivalence: `actual.ShouldBeEquivalentTo(expected)` — use where record equality
+  is wrong because a member (e.g. an `ImmutableDictionary`) compares by reference
+- Exception assertions use Shouldly's static form: `await Should.ThrowAsync<T>(act)` /
+  `Should.Throw<T>(action)` (the delegate is the argument, not the receiver)
 - Fake with FakeItEasy: `A.Fake<T>()` to create, `A.CallTo(() => ...)` to configure and assert
 - Internals can be made testable via `InternalsVisibleTo` in the src `.csproj` (already declared
   for `Ayaka.Nuke` and `Ayaka.MultiTenancy`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,19 +93,19 @@ Usings:
 
 - `ImplicitUsings` is enabled
 - `System.Diagnostics.CodeAnalysis` is a global using everywhere
-- Test projects additionally get `Xunit`, `FluentAssertions`, and `FakeItEasy` as global usings — no
+- Test projects additionally get `Xunit`, `Shouldly`, and `FakeItEasy` as global usings — no
   explicit `using` needed for these
 
 ## Tests
 
-xunit + FluentAssertions + FakeItEasy (see `eng/Packages.props` for versions).
+xunit + Shouldly + FakeItEasy (see `eng/Packages.props` for versions).
 
 - Test class: `<TypeUnderTest>Test` (singular, e.g. `AsyncLocalTenantContextAccessorTest`) in
   `test/<Project>.Tests` mirroring the source namespace
 - Group related cases in nested classes named after the member/scenario under test (e.g.
   `AddMultiTenancy`, `When`)
 - Method names are readable sentences in snake_case: `Getting_TenantContext_returns_null_when_no_TenantContext_is_set`
-- Assert with FluentAssertions (`.Should().Be...`), fake with FakeItEasy
+- Assert with Shouldly (`.ShouldBe(...)`), fake with FakeItEasy
 
 ## Commits, PRs, releases
 

--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -30,10 +30,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.analyzers" Version="1.27.0" />
   </ItemGroup>
 

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -12,12 +12,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/eng/Usings.props
+++ b/eng/Usings.props
@@ -11,7 +11,7 @@
   <!-- Global Usings for test projects -->
   <ItemGroup Condition="'$(IsTestProject)' == 'True'">
     <Using Include="FakeItEasy" />
-    <Using Include="FluentAssertions" />
+    <Using Include="Shouldly" />
     <Using Include="Xunit" />
   </ItemGroup>
 

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/DependencyInjection/ApplicationBuilderExtensionsTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/DependencyInjection/ApplicationBuilderExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Raphael Strotz. All rights reserved.
+// Copyright (c) Raphael Strotz. All rights reserved.
 
 namespace Ayaka.MultiTenancy.AspNetCore.Tests.DependencyInjection;
 
@@ -32,10 +32,8 @@ public sealed class ApplicationBuilderExtensionsTest
 
         var action = () => host.Start();
 
-        action
-            .Should()
-            .Throw<InvalidOperationException>()
-            .WithMessage(
+        Should.Throw<InvalidOperationException>(action)
+            .Message.ShouldBe(
                 "Unable to find the required services. " +
                 "Please add all the required services by calling 'IServiceCollection.AddMultiTenancy()' in the application startup code.");
     }

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/DependencyInjection/MultiTenancyBuilderExtensionsTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/DependencyInjection/MultiTenancyBuilderExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Raphael Strotz. All rights reserved.
+// Copyright (c) Raphael Strotz. All rights reserved.
 
 namespace Ayaka.MultiTenancy.AspNetCore.Tests.DependencyInjection;
 
@@ -14,7 +14,7 @@ public sealed class MultiTenancyBuilderExtensionsTest
 
         var result = builder.ConfigureRequestTenancy(_ => { });
 
-        result.Should().BeSameAs(builder);
+        result.ShouldBeSameAs(builder);
     }
 
     [Fact]
@@ -24,7 +24,7 @@ public sealed class MultiTenancyBuilderExtensionsTest
 
         builder.ConfigureRequestTenancy(requestTenancy =>
         {
-            requestTenancy.MultiTenancy.Should().BeSameAs(builder);
+            requestTenancy.MultiTenancy.ShouldBeSameAs(builder);
         });
     }
 

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/DependencyInjection/RequestTenancyBuilderTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/DependencyInjection/RequestTenancyBuilderTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Raphael Strotz. All rights reserved.
+// Copyright (c) Raphael Strotz. All rights reserved.
 
 namespace Ayaka.MultiTenancy.AspNetCore.Tests.DependencyInjection;
 
@@ -20,7 +20,7 @@ public sealed class RequestTenancyBuilderTest
         var sp = builder.Services.BuildServiceProvider();
         var options = sp.GetService<IOptions<RequestTenancyOptions>>();
 
-        options.Should().NotBeNull("IOptions<RequestTenancyOptions> should be registered");
+        options.ShouldNotBeNull("IOptions<RequestTenancyOptions> should be registered");
     }
 
     public sealed class DetectFromRequestHeader
@@ -35,12 +35,12 @@ public sealed class RequestTenancyBuilderTest
             var sp = builder.Services.BuildServiceProvider();
             var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
 
-            options.DetectionStrategies.Should().ContainSingle();
+            options.DetectionStrategies.ShouldHaveSingleItem();
 
             var strategy = options.DetectionStrategies[0];
 
-            strategy.Should().BeOfType<FromRequestHeaderStrategy>();
-            strategy.As<FromRequestHeaderStrategy>().HeaderName.Should().Be("foo");
+            strategy.ShouldBeOfType<FromRequestHeaderStrategy>()
+                .HeaderName.ShouldBe("foo");
         }
 
         [Fact]
@@ -57,11 +57,11 @@ public sealed class RequestTenancyBuilderTest
             var sp = builder.Services.BuildServiceProvider();
             var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
 
-            options.DetectionStrategies.Should().HaveCount(2);
-            options.DetectionStrategies.Should().AllBeOfType<FromRequestHeaderStrategy>();
+            options.DetectionStrategies.Count.ShouldBe(2);
+            options.DetectionStrategies.ShouldAllBe(x => x is FromRequestHeaderStrategy);
 
-            options.DetectionStrategies[0].As<FromRequestHeaderStrategy>().HeaderName.Should().Be("foo");
-            options.DetectionStrategies[1].As<FromRequestHeaderStrategy>().HeaderName.Should().Be("bar");
+            ((FromRequestHeaderStrategy)options.DetectionStrategies[0]).HeaderName.ShouldBe("foo");
+            ((FromRequestHeaderStrategy)options.DetectionStrategies[1]).HeaderName.ShouldBe("bar");
         }
     }
 
@@ -77,8 +77,7 @@ public sealed class RequestTenancyBuilderTest
             var sp = builder.Services.BuildServiceProvider();
             var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
 
-            options.DetectionStrategies.Should().ContainSingle();
-            options.DetectionStrategies.Should().AllBeOfType<FromRequestHostStrategy>();
+            options.DetectionStrategies.ShouldHaveSingleItem().ShouldBeOfType<FromRequestHostStrategy>();
         }
     }
 
@@ -94,8 +93,7 @@ public sealed class RequestTenancyBuilderTest
             var sp = builder.Services.BuildServiceProvider();
             var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
 
-            options.DetectionStrategies.Should().ContainSingle();
-            options.DetectionStrategies.Should().AllBeOfType<TestStrategy>();
+            options.DetectionStrategies.ShouldHaveSingleItem().ShouldBeOfType<TestStrategy>();
         }
 
         [Fact]
@@ -111,10 +109,10 @@ public sealed class RequestTenancyBuilderTest
             var sp = builder.Services.BuildServiceProvider();
             var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
 
-            options.DetectionStrategies.Should().ContainSingle();
-            options.DetectionStrategies.Should().AllBeOfType<TestStrategyWithDependency>();
+            var strategy = options.DetectionStrategies.ShouldHaveSingleItem();
 
-            options.DetectionStrategies[0].As<TestStrategyWithDependency>().Dependency.Should().BeSameAs(service);
+            strategy.ShouldBeOfType<TestStrategyWithDependency>()
+                .Dependency.ShouldBeSameAs(service);
         }
     }
 
@@ -131,8 +129,8 @@ public sealed class RequestTenancyBuilderTest
             var sp = builder.Services.BuildServiceProvider();
             var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
 
-            options.DetectionStrategies.Should().ContainSingle();
-            options.DetectionStrategies[0].Should().BeSameAs(strategy);
+            options.DetectionStrategies.ShouldHaveSingleItem();
+            options.DetectionStrategies[0].ShouldBeSameAs(strategy);
         }
     }
 
@@ -148,7 +146,7 @@ public sealed class RequestTenancyBuilderTest
             var sp = builder.Services.BuildServiceProvider();
             var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
 
-            options.ActivityTagName.Should().Be("tenant");
+            options.ActivityTagName.ShouldBe("tenant");
         }
 
         [Fact]
@@ -161,7 +159,7 @@ public sealed class RequestTenancyBuilderTest
             var sp = builder.Services.BuildServiceProvider();
             var options = sp.GetRequiredService<IOptions<RequestTenancyOptions>>().Value;
 
-            options.ActivityTagName.Should().Be("custom");
+            options.ActivityTagName.ShouldBe("custom");
         }
     }
 

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/Detection/FromRequestHeaderStrategyTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/Detection/FromRequestHeaderStrategyTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Raphael Strotz. All rights reserved.
+// Copyright (c) Raphael Strotz. All rights reserved.
 
 namespace Ayaka.MultiTenancy.AspNetCore.Tests.Detection;
 
@@ -13,7 +13,7 @@ public sealed class FromRequestHeaderStrategyTest
     {
         var actual = new FromRequestHeaderStrategy("X-Tenant-Id");
 
-        actual.HeaderName.Should().Be("X-Tenant-Id");
+        actual.HeaderName.ShouldBe("X-Tenant-Id");
     }
 
     [Fact]
@@ -27,7 +27,7 @@ public sealed class FromRequestHeaderStrategyTest
 
         var actual = await new FromRequestHeaderStrategy("X-Tenant-Id").TryDetectAsync(httpContext);
 
-        actual.Should().BeNull();
+        actual.ShouldBeNull();
     }
 
     [Theory]
@@ -50,7 +50,7 @@ public sealed class FromRequestHeaderStrategyTest
 
         var actual = await new FromRequestHeaderStrategy("X-Tenant-Id").TryDetectAsync(httpContext);
 
-        actual.Should().BeNull();
+        actual.ShouldBeNull();
     }
 
     [Fact]
@@ -70,7 +70,7 @@ public sealed class FromRequestHeaderStrategyTest
 
         var actual = await new FromRequestHeaderStrategy("X-Tenant-Id").TryDetectAsync(httpContext);
 
-        actual.Should().Be("example");
+        actual.ShouldBe("example");
     }
 
     [Fact]
@@ -90,6 +90,6 @@ public sealed class FromRequestHeaderStrategyTest
 
         var actual = await new FromRequestHeaderStrategy("X-Tenant-Id").TryDetectAsync(httpContext);
 
-        actual.Should().Be("example");
+        actual.ShouldBe("example");
     }
 }

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/Detection/FromRequestHostStrategyTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/Detection/FromRequestHostStrategyTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Raphael Strotz. All rights reserved.
+// Copyright (c) Raphael Strotz. All rights reserved.
 
 namespace Ayaka.MultiTenancy.AspNetCore.Tests.Detection;
 
@@ -18,7 +18,7 @@ public sealed class FromRequestHostStrategyTest
 
         var actual = await new FromRequestHostStrategy().TryDetectAsync(httpContext);
 
-        actual.Should().BeNull();
+        actual.ShouldBeNull();
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public sealed class FromRequestHostStrategyTest
 
         var actual = await new FromRequestHostStrategy().TryDetectAsync(httpContext);
 
-        actual.Should().BeNull();
+        actual.ShouldBeNull();
     }
 
     [Theory]
@@ -49,6 +49,6 @@ public sealed class FromRequestHostStrategyTest
 
         var actual = await new FromRequestHostStrategy().TryDetectAsync(httpContext);
 
-        actual.Should().Be(expectedTenantId);
+        actual.ShouldBe(expectedTenantId);
     }
 }

--- a/test/Ayaka.MultiTenancy.AspNetCore.Tests/RequestTenancyMiddlewareTest.cs
+++ b/test/Ayaka.MultiTenancy.AspNetCore.Tests/RequestTenancyMiddlewareTest.cs
@@ -3,6 +3,7 @@
 namespace Ayaka.MultiTenancy.AspNetCore.Tests;
 
 using System.Diagnostics;
+using System.Net;
 using Ayaka.MultiTenancy.AspNetCore.Detection;
 using Ayaka.MultiTenancy.AspNetCore.Tests.Internal;
 using Ayaka.MultiTenancy.DependencyInjection;
@@ -55,10 +56,9 @@ public abstract class RequestTenancyMiddlewareTest
 
         var action = () => client.GetAsync("/");
 
-        await action
-            .Should()
-            .ThrowAsync<InvalidOperationException>()
-            .WithMessage("Tenant was already set previously in the request pipeline");
+        (await Should.ThrowAsync<InvalidOperationException>(action))
+            .Message.ShouldBe(
+                "Tenant was already set previously in the request pipeline");
     }
 
     [Fact]
@@ -84,10 +84,9 @@ public abstract class RequestTenancyMiddlewareTest
 
         var action = () => client.GetAsync("/tenancy-enabled");
 
-        await action
-            .Should()
-            .ThrowAsync<InvalidOperationException>()
-            .WithMessage("No tenant detection strategies are configured");
+        (await Should.ThrowAsync<InvalidOperationException>(action))
+            .Message.ShouldBe(
+                "No tenant detection strategies are configured");
     }
 
     [Fact]
@@ -116,7 +115,7 @@ public abstract class RequestTenancyMiddlewareTest
         using var response = await client.GetAsync("/tenancy-disabled", TestContext.Current.CancellationToken);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
-        content.Should().Be("no tenant", "because the tenant id should not be set");
+        content.ShouldBe("no tenant", "because the tenant id should not be set");
     }
 
     [Fact]
@@ -146,7 +145,7 @@ public abstract class RequestTenancyMiddlewareTest
 
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
-        content.Should().Be("test", "because the tenant id should be set");
+        content.ShouldBe("test", "because the tenant id should be set");
     }
 
     [Fact]
@@ -177,7 +176,7 @@ public abstract class RequestTenancyMiddlewareTest
         using var response = await client.GetAsync("/tenancy-enabled", TestContext.Current.CancellationToken);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
-        content.Should().Be("test", "because the tenant id should be set");
+        content.ShouldBe("test", "because the tenant id should be set");
     }
 
     [Fact]
@@ -206,7 +205,7 @@ public abstract class RequestTenancyMiddlewareTest
         using var response = await client.GetAsync("/tenancy-enabled", TestContext.Current.CancellationToken);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
-        content.Should().Be("no tenant", "because the tenant id should not be set");
+        content.ShouldBe("no tenant", "because the tenant id should not be set");
     }
 
     [Fact]
@@ -238,10 +237,10 @@ public abstract class RequestTenancyMiddlewareTest
 
         using var client = host.GetTestClient();
         using var response = await client.GetAsync("/tenancy-enabled", TestContext.Current.CancellationToken);
-        response.Should().BeSuccessful();
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-        tracker.StoppedActivities.Should().ContainSingle();
-        tracker.StoppedActivities[0].Tags.Should().ContainSingle(x => x.Key == "custom" && x.Value == "test");
+        tracker.StoppedActivities.ShouldHaveSingleItem();
+        tracker.StoppedActivities[0].Tags.ShouldContain(x => x.Key == "custom" && x.Value == "test", 1);
     }
 
     protected virtual void ConfigureServices(IServiceCollection services)
@@ -316,7 +315,7 @@ public abstract class RequestTenancyMiddlewareTest
             using var response = await client.GetAsync("/inherited-tenancy-disabled", TestContext.Current.CancellationToken);
             var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
-            content.Should().Be("no tenant", "because the tenant id should not be set");
+            content.ShouldBe("no tenant", "because the tenant id should not be set");
         }
 
         private sealed class TestController : ControllerBase

--- a/test/Ayaka.MultiTenancy.Tests/AsyncLocalTenantContextAccessorTest.cs
+++ b/test/Ayaka.MultiTenancy.Tests/AsyncLocalTenantContextAccessorTest.cs
@@ -15,7 +15,7 @@ public sealed class AsyncLocalTenantContextAccessorTest
 
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
-        accessor.TenantContext.Should().BeSameAs(context);
+        accessor.TenantContext.ShouldBeSameAs(context);
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public sealed class AsyncLocalTenantContextAccessorTest
     {
         var accessor = new AsyncLocalTenantContextAccessor();
 
-        accessor.TenantContext.Should().BeNull();
+        accessor.TenantContext.ShouldBeNull();
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public sealed class AsyncLocalTenantContextAccessorTest
         ThreadPool.QueueUserWorkItem(async _ =>
         {
             // Make sure the TenantContext flows with the execution context
-            accessor.TenantContext.Should().BeSameAs(context);
+            accessor.TenantContext.ShouldBeSameAs(context);
 
             // Signal the outer code to continue
             checkAsyncFlowTcs.SetResult();
@@ -54,7 +54,7 @@ public sealed class AsyncLocalTenantContextAccessorTest
             try
             {
                 // Make sure the TenantContext is now null
-                accessor.TenantContext.Should().BeNull();
+                accessor.TenantContext.ShouldBeNull();
 
                 // Signal the outer code to continue
                 afterNullCheckTcs.SetResult();
@@ -76,7 +76,7 @@ public sealed class AsyncLocalTenantContextAccessorTest
         // Signal the thread pool callback to continue
         waitForNullTcs.SetResult();
 
-        accessor.TenantContext.Should().BeNull();
+        accessor.TenantContext.ShouldBeNull();
 
         // Wait for the thread pool callback to complete
         await afterNullCheckTcs.Task;
@@ -99,7 +99,7 @@ public sealed class AsyncLocalTenantContextAccessorTest
         ThreadPool.QueueUserWorkItem(async _ =>
         {
             // Make sure the TenantContext flows with the execution context
-            accessor.TenantContext.Should().BeSameAs(context);
+            accessor.TenantContext.ShouldBeSameAs(context);
 
             // Signal the outer code to continue
             checkAsyncFlowTcs.SetResult();
@@ -110,7 +110,7 @@ public sealed class AsyncLocalTenantContextAccessorTest
             try
             {
                 // Make sure the TenantContext is now null
-                accessor.TenantContext.Should().BeNull();
+                accessor.TenantContext.ShouldBeNull();
 
                 // Signal the outer code to continue
                 afterNullCheckTcs.SetResult();
@@ -133,7 +133,7 @@ public sealed class AsyncLocalTenantContextAccessorTest
         // Signal the thread pool callback to continue
         waitForNullTcs.SetResult();
 
-        accessor.TenantContext.Should().BeSameAs(context2);
+        accessor.TenantContext.ShouldBeSameAs(context2);
 
         // Wait for the thread pool callback to complete
         await afterNullCheckTcs.Task;
@@ -158,7 +158,7 @@ public sealed class AsyncLocalTenantContextAccessorTest
             try
             {
                 // Make sure the TenantContext flows with the execution context
-                accessor.TenantContext.Should().BeNull();
+                accessor.TenantContext.ShouldBeNull();
 
                 // Signal the outer code to continue
                 checkAsyncFlowTcs.SetResult();
@@ -190,7 +190,7 @@ public sealed class AsyncLocalTenantContextAccessorTest
             try
             {
                 // Make sure the TenantContext flows with the execution context
-                accessor.TenantContext.Should().BeNull();
+                accessor.TenantContext.ShouldBeNull();
 
                 // Signal the outer code to continue
                 checkAsyncFlowTcs.SetResult();

--- a/test/Ayaka.MultiTenancy.Tests/DependencyInjection/MultiTenancyBuilderExtensionsTest.cs
+++ b/test/Ayaka.MultiTenancy.Tests/DependencyInjection/MultiTenancyBuilderExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Raphael Strotz. All rights reserved.
+// Copyright (c) Raphael Strotz. All rights reserved.
 
 namespace Ayaka.MultiTenancy.Tests.DependencyInjection;
 
@@ -17,8 +17,7 @@ public sealed class MultiTenancyBuilderExtensionsTest
 
             var tenantManagementBuilder = builder.AddTenantManagement();
 
-            tenantManagementBuilder.Should().NotBeNull();
-            tenantManagementBuilder.Should().BeOfType<TenantManagementBuilder>();
+            tenantManagementBuilder.ShouldBeOfType<TenantManagementBuilder>();
         }
 
         [Fact]
@@ -28,7 +27,7 @@ public sealed class MultiTenancyBuilderExtensionsTest
 
             var tenantManagementBuilder = builder.AddTenantManagement();
 
-            tenantManagementBuilder.MultiTenancy.Should().BeSameAs(builder);
+            tenantManagementBuilder.MultiTenancy.ShouldBeSameAs(builder);
         }
 
         [Fact]
@@ -39,7 +38,7 @@ public sealed class MultiTenancyBuilderExtensionsTest
             builder.AddTenantManagement();
 
             var manager = builder.Services.FirstOrDefault(x => x.ServiceType == typeof(ITenantManager));
-            manager.Should().NotBeNull("ITenantManager should be registered");
+            manager.ShouldNotBeNull("ITenantManager should be registered");
         }
 
         [Fact]
@@ -50,7 +49,7 @@ public sealed class MultiTenancyBuilderExtensionsTest
             builder.AddTenantManagement();
             builder.AddTenantManagement();
 
-            builder.Services.Count(x => x.ServiceType == typeof(ITenantManager)).Should().Be(1);
+            builder.Services.Count(x => x.ServiceType == typeof(ITenantManager)).ShouldBe(1);
         }
     }
 

--- a/test/Ayaka.MultiTenancy.Tests/DependencyInjection/TenantManagementBuilderExtensions.cs
+++ b/test/Ayaka.MultiTenancy.Tests/DependencyInjection/TenantManagementBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Raphael Strotz. All rights reserved.
+// Copyright (c) Raphael Strotz. All rights reserved.
 
 namespace Ayaka.MultiTenancy.Tests.DependencyInjection;
 
@@ -17,7 +17,7 @@ public sealed class TenantManagementBuilderExtensions
 
             var result = builder.UseInMemoryStore();
 
-            result.Should().BeSameAs(builder);
+            result.ShouldBeSameAs(builder);
         }
 
         [Fact]
@@ -29,8 +29,8 @@ public sealed class TenantManagementBuilderExtensions
 
             var store = builder.MultiTenancy.Services.FirstOrDefault(x => x.ServiceType == typeof(ITenantStore));
 
-            store.Should().NotBeNull("ITenantStore should be registered");
-            store.ImplementationType.Should().Be(typeof(InMemoryTenantStore));
+            store.ShouldNotBeNull("ITenantStore should be registered");
+            store.ImplementationType.ShouldBe(typeof(InMemoryTenantStore));
         }
 
         [Fact]
@@ -43,8 +43,8 @@ public sealed class TenantManagementBuilderExtensions
 
             var store = builder.MultiTenancy.Services.FirstOrDefault(x => x.ServiceType == typeof(ITenantStore));
 
-            store.Should().NotBeNull("ITenantStore should be registered");
-            store.ImplementationType.Should().Be(typeof(TestTenantStore));
+            store.ShouldNotBeNull("ITenantStore should be registered");
+            store.ImplementationType.ShouldBe(typeof(TestTenantStore));
         }
     }
 

--- a/test/Ayaka.MultiTenancy.Tests/Management/DefaultTenantManagerTest.cs
+++ b/test/Ayaka.MultiTenancy.Tests/Management/DefaultTenantManagerTest.cs
@@ -45,7 +45,7 @@ public sealed class DefaultTenantManagerTest
 
         var result = await tenantManager.GetAsync(tenantId, TestContext.Current.CancellationToken);
 
-        result.Should().Be(tenant);
+        result.ShouldBe(tenant);
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public sealed class DefaultTenantManagerTest
 
         var result = await tenantManager.GetAsync(tenantId, TestContext.Current.CancellationToken);
 
-        result.Should().BeNull();
+        result.ShouldBeNull();
     }
 
     [Fact]
@@ -79,6 +79,6 @@ public sealed class DefaultTenantManagerTest
 
         var result = await tenantManager.GetAllAsync(TestContext.Current.CancellationToken);
 
-        result.Should().BeEquivalentTo(tenants);
+        result.ShouldBeEquivalentTo(tenants);
     }
 }

--- a/test/Ayaka.MultiTenancy.Tests/Management/InMemoryTenantStoreTest.cs
+++ b/test/Ayaka.MultiTenancy.Tests/Management/InMemoryTenantStoreTest.cs
@@ -20,9 +20,9 @@ public sealed class InMemoryTenantStoreTest : TenantStoreCompliance<InMemoryStor
         await store1.AddAsync(new Tenant("tenant1"), TestContext.Current.CancellationToken);
 
         var tenantsFromStore1 = await store1.GetAllAsync(TestContext.Current.CancellationToken);
-        tenantsFromStore1.Should().ContainSingle();
+        tenantsFromStore1.ShouldHaveSingleItem();
 
         var tenantsFromStore2 = await store2.GetAllAsync(TestContext.Current.CancellationToken);
-        tenantsFromStore2.Should().BeEmpty();
+        tenantsFromStore2.ShouldBeEmpty();
     }
 }

--- a/test/Ayaka.MultiTenancy.Tests/Management/TenantStoreCompliance.cs
+++ b/test/Ayaka.MultiTenancy.Tests/Management/TenantStoreCompliance.cs
@@ -19,8 +19,7 @@ public abstract class TenantStoreCompliance<TStoreFixture> : IDisposable, IAsync
         await store.AddAsync(tenant, TestContext.Current.CancellationToken);
 
         var tenants = await store.GetAllAsync(TestContext.Current.CancellationToken);
-        tenants.Should().ContainSingle();
-        tenants.Should().ContainEquivalentOf(tenant);
+        tenants.ShouldHaveSingleItem().ShouldBeEquivalentTo(tenant);
     }
 
     [Fact]
@@ -32,8 +31,7 @@ public abstract class TenantStoreCompliance<TStoreFixture> : IDisposable, IAsync
         await store.AddAsync(tenant, TestContext.Current.CancellationToken);
 
         var tenants = await store.GetAllAsync(TestContext.Current.CancellationToken);
-        tenants.Should().ContainSingle();
-        tenants.Should().ContainEquivalentOf(tenant);
+        tenants.ShouldHaveSingleItem().ShouldBeEquivalentTo(tenant);
     }
 
     [Fact]
@@ -51,8 +49,7 @@ public abstract class TenantStoreCompliance<TStoreFixture> : IDisposable, IAsync
         await store.AddAsync(tenant, TestContext.Current.CancellationToken);
 
         var tenants = await store.GetAllAsync(TestContext.Current.CancellationToken);
-        tenants.Should().ContainSingle();
-        tenants.Should().ContainEquivalentOf(tenant);
+        tenants.ShouldHaveSingleItem().ShouldBeEquivalentTo(tenant);
     }
 
     [Fact]
@@ -66,7 +63,7 @@ public abstract class TenantStoreCompliance<TStoreFixture> : IDisposable, IAsync
             async (i, ct) => await store.AddAsync(new Tenant("tenant" + i), ct));
 
         var tenants = await store.GetAllAsync(TestContext.Current.CancellationToken);
-        tenants.Should().HaveCount(100);
+        tenants.Count.ShouldBe(100);
     }
 
     [Fact]
@@ -77,7 +74,8 @@ public abstract class TenantStoreCompliance<TStoreFixture> : IDisposable, IAsync
 
         var act = async () => await store.AddAsync(new Tenant("tenant1"));
 
-        await act.Should().ThrowAsync<TenantManagementException>().WithMessage("Tenant with id 'tenant1' already exists");
+        (await Should.ThrowAsync<TenantManagementException>(act))
+            .Message.ShouldBe("Tenant with id 'tenant1' already exists");
     }
 
     [Fact]
@@ -95,8 +93,7 @@ public abstract class TenantStoreCompliance<TStoreFixture> : IDisposable, IAsync
         await store.UpdateAsync(updatedTenant, TestContext.Current.CancellationToken);
 
         var tenants = await store.GetAllAsync(TestContext.Current.CancellationToken);
-        tenants.Should().ContainSingle();
-        tenants.Should().ContainEquivalentOf(updatedTenant);
+        tenants.ShouldHaveSingleItem().ShouldBeEquivalentTo(updatedTenant);
     }
 
     [Fact]
@@ -120,12 +117,11 @@ public abstract class TenantStoreCompliance<TStoreFixture> : IDisposable, IAsync
         await store.UpdateAsync(updatedTenant, TestContext.Current.CancellationToken);
 
         var tenants = await store.GetAllAsync(TestContext.Current.CancellationToken);
-        tenants.Should().ContainSingle();
-        tenants.Should().ContainEquivalentOf(updatedTenant);
+        tenants.ShouldHaveSingleItem().ShouldBeEquivalentTo(updatedTenant);
     }
 
     [Fact]
-    public Task Throws_when_updating_non_existing_tenant()
+    public async Task Throws_when_updating_non_existing_tenant()
     {
         var store = StoreFixture.Store;
         var tenant = new Tenant(
@@ -143,7 +139,8 @@ public abstract class TenantStoreCompliance<TStoreFixture> : IDisposable, IAsync
 
         var act = async () => await store.UpdateAsync(updatedTenant);
 
-        return act.Should().ThrowAsync<TenantManagementException>().WithMessage("Tenant with id 'tenant1' does not exist");
+        (await Should.ThrowAsync<TenantManagementException>(act))
+            .Message.ShouldBe("Tenant with id 'tenant1' does not exist");
     }
 
     [Fact]
@@ -154,12 +151,12 @@ public abstract class TenantStoreCompliance<TStoreFixture> : IDisposable, IAsync
 
         // Make sure the tenant was added
         var tenants = await store.GetAllAsync(TestContext.Current.CancellationToken);
-        tenants.Should().ContainSingle();
+        tenants.ShouldHaveSingleItem();
 
         await store.RemoveAsync("tenant1", TestContext.Current.CancellationToken);
 
         tenants = await store.GetAllAsync(TestContext.Current.CancellationToken);
-        tenants.Should().BeEmpty();
+        tenants.ShouldBeEmpty();
     }
 
     [Fact]
@@ -169,7 +166,7 @@ public abstract class TenantStoreCompliance<TStoreFixture> : IDisposable, IAsync
 
         var act = async () => await store.RemoveAsync("tenant1");
 
-        return act.Should().NotThrowAsync();
+        return Should.NotThrowAsync(act);
     }
 
     public ValueTask InitializeAsync()

--- a/test/Ayaka.MultiTenancy.Tests/ServiceCollectionExtensionsTest.cs
+++ b/test/Ayaka.MultiTenancy.Tests/ServiceCollectionExtensionsTest.cs
@@ -16,8 +16,7 @@ public sealed class ServiceCollectionExtensionsTest
 
             var builder = services.AddMultiTenancy();
 
-            builder.Should().NotBeNull();
-            builder.Should().BeOfType<MultiTenancyBuilder>();
+            builder.ShouldBeOfType<MultiTenancyBuilder>();
         }
 
         [Fact]
@@ -27,7 +26,7 @@ public sealed class ServiceCollectionExtensionsTest
 
             var builder = services.AddMultiTenancy();
 
-            builder.Services.Should().BeSameAs(services);
+            builder.Services.ShouldBeSameAs(services);
         }
 
         [Fact]
@@ -38,7 +37,7 @@ public sealed class ServiceCollectionExtensionsTest
             services.AddMultiTenancy();
 
             var accessor = services.FirstOrDefault(x => x.ServiceType == typeof(ITenantContextAccessor));
-            accessor.Should().NotBeNull("ITenantContextAccessor should be registered");
+            accessor.ShouldNotBeNull("ITenantContextAccessor should be registered");
         }
 
         [Fact]
@@ -49,7 +48,7 @@ public sealed class ServiceCollectionExtensionsTest
             services.AddMultiTenancy();
             services.AddMultiTenancy();
 
-            services.Count(x => x.ServiceType == typeof(ITenantContextAccessor)).Should().Be(1);
+            services.Count(x => x.ServiceType == typeof(ITenantContextAccessor)).ShouldBe(1);
         }
     }
 
@@ -64,8 +63,8 @@ public sealed class ServiceCollectionExtensionsTest
 
             var accessor = services.FirstOrDefault(x => x.ServiceType == typeof(ITenantContextAccessor));
 
-            accessor.Should().NotBeNull();
-            accessor!.Lifetime.Should().Be(ServiceLifetime.Singleton);
+            accessor.ShouldNotBeNull();
+            accessor.Lifetime.ShouldBe(ServiceLifetime.Singleton);
         }
 
         [Fact]
@@ -77,14 +76,13 @@ public sealed class ServiceCollectionExtensionsTest
             services.AddTenantContextAccessor();
 
             var accessor = services.FirstOrDefault(x => x.ServiceType == typeof(ITenantContextAccessor));
-            accessor.Should().NotBeNull();
-            accessor!.Lifetime.Should().Be(ServiceLifetime.Scoped);
+            accessor.ShouldNotBeNull();
+            accessor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
 
             var serviceProvider = services.BuildServiceProvider();
             serviceProvider
                 .GetRequiredService<ITenantContextAccessor>()
-                .Should()
-                .BeOfType<TestTenantContextAccessor>();
+                .ShouldBeOfType<TestTenantContextAccessor>();
         }
 
         [Fact]
@@ -92,7 +90,7 @@ public sealed class ServiceCollectionExtensionsTest
         {
             var services = new ServiceCollection();
 
-            services.AddTenantContextAccessor().Should().BeSameAs(services);
+            services.AddTenantContextAccessor().ShouldBeSameAs(services);
         }
 
         private sealed class TestTenantContextAccessor : ITenantContextAccessor

--- a/test/Ayaka.Nuke.Tests/DotNetValidate/DotNetValidateLocalPackageSettingsExtensionsTest.cs
+++ b/test/Ayaka.Nuke.Tests/DotNetValidate/DotNetValidateLocalPackageSettingsExtensionsTest.cs
@@ -13,9 +13,9 @@ public sealed class DotNetValidateLocalPackageSettingsExtensionsTest
 
         var actual = original.SetPackagePath("path/to/package");
 
-        actual.Should().NotBeSameAs(original);
-        original.PackagePath.Should().Be(expected: null);
-        actual.PackagePath.Should().Be("path/to/package");
+        actual.ShouldNotBeSameAs(original);
+        original.PackagePath.ShouldBeNull();
+        actual.PackagePath.ShouldBe("path/to/package");
     }
 
     [Fact]
@@ -26,8 +26,8 @@ public sealed class DotNetValidateLocalPackageSettingsExtensionsTest
 
         var actual = original.ResetPackagePath();
 
-        actual.Should().NotBeSameAs(original);
-        original.PackagePath.Should().Be("path/to/package");
-        actual.PackagePath.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.PackagePath.ShouldBe("path/to/package");
+        actual.PackagePath.ShouldBeNull();
     }
 }

--- a/test/Ayaka.Nuke.Tests/DotNetValidate/DotNetValidateRemotePackageSettingsExtensionsTest.cs
+++ b/test/Ayaka.Nuke.Tests/DotNetValidate/DotNetValidateRemotePackageSettingsExtensionsTest.cs
@@ -13,9 +13,9 @@ public sealed class DotNetValidateRemotePackageSettingsExtensionsTest
 
         var actual = original.SetPackageId("mypackage");
 
-        actual.Should().NotBeSameAs(original);
-        original.PackageId.Should().Be(expected: null);
-        actual.PackageId.Should().Be("mypackage");
+        actual.ShouldNotBeSameAs(original);
+        original.PackageId.ShouldBeNull();
+        actual.PackageId.ShouldBe("mypackage");
     }
 
     [Fact]
@@ -26,9 +26,9 @@ public sealed class DotNetValidateRemotePackageSettingsExtensionsTest
 
         var actual = original.ResetPackageId();
 
-        actual.Should().NotBeSameAs(original);
-        original.PackageId.Should().Be("mypackage");
-        actual.PackageId.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.PackageId.ShouldBe("mypackage");
+        actual.PackageId.ShouldBeNull();
     }
 
     [Fact]
@@ -38,9 +38,9 @@ public sealed class DotNetValidateRemotePackageSettingsExtensionsTest
 
         var actual = original.SetPackageVersion("1.2.3.4");
 
-        actual.Should().NotBeSameAs(original);
-        original.PackageVersion.Should().Be(expected: null);
-        actual.PackageVersion.Should().Be("1.2.3.4");
+        actual.ShouldNotBeSameAs(original);
+        original.PackageVersion.ShouldBeNull();
+        actual.PackageVersion.ShouldBe("1.2.3.4");
     }
 
     [Fact]
@@ -51,9 +51,9 @@ public sealed class DotNetValidateRemotePackageSettingsExtensionsTest
 
         var actual = original.ResetPackageVersion();
 
-        actual.Should().NotBeSameAs(original);
-        original.PackageVersion.Should().Be("1.2.3.4");
-        actual.PackageVersion.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.PackageVersion.ShouldBe("1.2.3.4");
+        actual.PackageVersion.ShouldBeNull();
     }
 
     [Fact]
@@ -63,9 +63,9 @@ public sealed class DotNetValidateRemotePackageSettingsExtensionsTest
 
         var actual = original.SetConfigDirectory("path/to/directory");
 
-        actual.Should().NotBeSameAs(original);
-        original.ConfigDirectory.Should().Be(expected: null);
-        actual.ConfigDirectory.Should().Be("path/to/directory");
+        actual.ShouldNotBeSameAs(original);
+        original.ConfigDirectory.ShouldBeNull();
+        actual.ConfigDirectory.ShouldBe("path/to/directory");
     }
 
     [Fact]
@@ -76,8 +76,8 @@ public sealed class DotNetValidateRemotePackageSettingsExtensionsTest
 
         var actual = original.ResetConfigDirectory();
 
-        actual.Should().NotBeSameAs(original);
-        original.ConfigDirectory.Should().Be("path/to/directory");
-        actual.ConfigDirectory.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.ConfigDirectory.ShouldBe("path/to/directory");
+        actual.ConfigDirectory.ShouldBeNull();
     }
 }

--- a/test/Ayaka.Nuke.Tests/ExtensionsTest.cs
+++ b/test/Ayaka.Nuke.Tests/ExtensionsTest.cs
@@ -13,7 +13,7 @@ public sealed class ExtensionsTest
 
             var actual = settings.When(true, s => s.EnableFlag());
 
-            actual.Should().BeEquivalentTo(new TestSettings(Flag: true));
+            actual.ShouldBe(new TestSettings(Flag: true));
         }
 
         [Fact]
@@ -23,7 +23,7 @@ public sealed class ExtensionsTest
 
             var actual = settings.When(false, s => s.EnableFlag());
 
-            actual.Should().BeEquivalentTo(new TestSettings(Flag: false));
+            actual.ShouldBe(new TestSettings(Flag: false));
         }
 
         private sealed record TestSettings(bool Flag)
@@ -43,7 +43,7 @@ public sealed class ExtensionsTest
 
             var actual = settings.WhenNotNull(obj, (s, o) => s.EnableFlag());
 
-            actual.Should().BeEquivalentTo(new TestSettings(Flag: true));
+            actual.ShouldBe(new TestSettings(Flag: true));
         }
 
         [Fact]
@@ -54,7 +54,7 @@ public sealed class ExtensionsTest
 
             var actual = settings.WhenNotNull(obj, (s, o) => s.EnableFlag());
 
-            actual.Should().BeEquivalentTo(new TestSettings(Flag: false));
+            actual.ShouldBe(new TestSettings(Flag: false));
         }
 
         private sealed record TestSettings(bool Flag)

--- a/test/Ayaka.Nuke.Tests/GitHub/GitHubPullRequestSettingsExtensionsTest.cs
+++ b/test/Ayaka.Nuke.Tests/GitHub/GitHubPullRequestSettingsExtensionsTest.cs
@@ -14,9 +14,9 @@ public sealed class GitHubPullRequestSettingsExtensionsTest
 
         var actual = original.SetHead("feature/awesome");
 
-        actual.Should().NotBeSameAs(original);
-        original.Head.Should().Be(expected: null);
-        actual.Head.Should().Be("feature/awesome");
+        actual.ShouldNotBeSameAs(original);
+        original.Head.ShouldBeNull();
+        actual.Head.ShouldBe("feature/awesome");
     }
 
     [Fact]
@@ -27,9 +27,9 @@ public sealed class GitHubPullRequestSettingsExtensionsTest
 
         var actual = original.ResetHead();
 
-        actual.Should().NotBeSameAs(original);
-        original.Head.Should().Be("feature/awesome");
-        actual.Head.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.Head.ShouldBe("feature/awesome");
+        actual.Head.ShouldBeNull();
     }
 
     [Fact]
@@ -39,9 +39,9 @@ public sealed class GitHubPullRequestSettingsExtensionsTest
 
         var actual = original.SetBase("main");
 
-        actual.Should().NotBeSameAs(original);
-        original.Base.Should().Be(expected: null);
-        actual.Base.Should().Be("main");
+        actual.ShouldNotBeSameAs(original);
+        original.Base.ShouldBeNull();
+        actual.Base.ShouldBe("main");
     }
 
     [Fact]
@@ -52,9 +52,9 @@ public sealed class GitHubPullRequestSettingsExtensionsTest
 
         var actual = original.ResetBase();
 
-        actual.Should().NotBeSameAs(original);
-        original.Base.Should().Be("main");
-        actual.Base.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.Base.ShouldBe("main");
+        actual.Base.ShouldBeNull();
     }
 
     [Fact]
@@ -64,9 +64,9 @@ public sealed class GitHubPullRequestSettingsExtensionsTest
 
         var actual = original.SetTitle("Add new feature");
 
-        actual.Should().NotBeSameAs(original);
-        original.Title.Should().Be(expected: null);
-        actual.Title.Should().Be("Add new feature");
+        actual.ShouldNotBeSameAs(original);
+        original.Title.ShouldBeNull();
+        actual.Title.ShouldBe("Add new feature");
     }
 
     [Fact]
@@ -77,9 +77,9 @@ public sealed class GitHubPullRequestSettingsExtensionsTest
 
         var actual = original.ResetTitle();
 
-        actual.Should().NotBeSameAs(original);
-        original.Title.Should().Be("Add new feature");
-        actual.Title.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.Title.ShouldBe("Add new feature");
+        actual.Title.ShouldBeNull();
     }
 
     [Fact]
@@ -89,9 +89,9 @@ public sealed class GitHubPullRequestSettingsExtensionsTest
 
         var actual = original.SetBody("This pull request adds a new feature.");
 
-        actual.Should().NotBeSameAs(original);
-        original.Body.Should().Be(expected: null);
-        actual.Body.Should().Be("This pull request adds a new feature.");
+        actual.ShouldNotBeSameAs(original);
+        original.Body.ShouldBeNull();
+        actual.Body.ShouldBe("This pull request adds a new feature.");
     }
 
     [Fact]
@@ -102,9 +102,9 @@ public sealed class GitHubPullRequestSettingsExtensionsTest
 
         var actual = original.ResetBody();
 
-        actual.Should().NotBeSameAs(original);
-        original.Body.Should().Be("This pull request adds a new feature.");
-        actual.Body.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.Body.ShouldBe("This pull request adds a new feature.");
+        actual.Body.ShouldBeNull();
     }
 
     [Fact]
@@ -114,9 +114,9 @@ public sealed class GitHubPullRequestSettingsExtensionsTest
 
         var actual = original.SetDraft(true);
 
-        actual.Should().NotBeSameAs(original);
-        original.Draft.Should().Be(expected: null);
-        actual.Draft.Should().Be(true);
+        actual.ShouldNotBeSameAs(original);
+        original.Draft.ShouldBeNull();
+        actual.Draft.ShouldBe(true);
     }
 
     [Fact]
@@ -127,8 +127,8 @@ public sealed class GitHubPullRequestSettingsExtensionsTest
 
         var actual = original.ResetDraft();
 
-        actual.Should().NotBeSameAs(original);
-        original.Draft.Should().Be(true);
-        actual.Draft.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.Draft.ShouldBe(true);
+        actual.Draft.ShouldBeNull();
     }
 }

--- a/test/Ayaka.Nuke.Tests/GitHub/GitHubReleaseNotesSettingsExtensionsTest.cs
+++ b/test/Ayaka.Nuke.Tests/GitHub/GitHubReleaseNotesSettingsExtensionsTest.cs
@@ -14,9 +14,9 @@ public sealed class GitHubReleaseNotesSettingsExtensionsTest
 
         var actual = original.SetTag("v1.0");
 
-        actual.Should().NotBeSameAs(original);
-        original.Tag.Should().Be(expected: null);
-        actual.Tag.Should().Be("v1.0");
+        actual.ShouldNotBeSameAs(original);
+        original.Tag.ShouldBeNull();
+        actual.Tag.ShouldBe("v1.0");
     }
 
     [Fact]
@@ -27,9 +27,9 @@ public sealed class GitHubReleaseNotesSettingsExtensionsTest
 
         var actual = original.ResetTag();
 
-        actual.Should().NotBeSameAs(original);
-        original.Tag.Should().Be("v1.0");
-        actual.Tag.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.Tag.ShouldBe("v1.0");
+        actual.Tag.ShouldBeNull();
     }
 
     [Fact]
@@ -39,9 +39,9 @@ public sealed class GitHubReleaseNotesSettingsExtensionsTest
 
         var actual = original.SetTargetCommitish("main");
 
-        actual.Should().NotBeSameAs(original);
-        original.TargetCommitish.Should().Be(expected: null);
-        actual.TargetCommitish.Should().Be("main");
+        actual.ShouldNotBeSameAs(original);
+        original.TargetCommitish.ShouldBeNull();
+        actual.TargetCommitish.ShouldBe("main");
     }
 
     [Fact]
@@ -52,9 +52,9 @@ public sealed class GitHubReleaseNotesSettingsExtensionsTest
 
         var actual = original.ResetTargetCommitish();
 
-        actual.Should().NotBeSameAs(original);
-        original.TargetCommitish.Should().Be("main");
-        actual.TargetCommitish.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.TargetCommitish.ShouldBe("main");
+        actual.TargetCommitish.ShouldBeNull();
     }
 
     [Fact]
@@ -64,9 +64,9 @@ public sealed class GitHubReleaseNotesSettingsExtensionsTest
 
         var actual = original.SetPreviousTag("v0.9");
 
-        actual.Should().NotBeSameAs(original);
-        original.PreviousTag.Should().Be(expected: null);
-        actual.PreviousTag.Should().Be("v0.9");
+        actual.ShouldNotBeSameAs(original);
+        original.PreviousTag.ShouldBeNull();
+        actual.PreviousTag.ShouldBe("v0.9");
     }
 
     [Fact]
@@ -77,9 +77,9 @@ public sealed class GitHubReleaseNotesSettingsExtensionsTest
 
         var actual = original.ResetPreviousTag();
 
-        actual.Should().NotBeSameAs(original);
-        original.PreviousTag.Should().Be("v0.9");
-        actual.PreviousTag.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.PreviousTag.ShouldBe("v0.9");
+        actual.PreviousTag.ShouldBeNull();
     }
 
     [Fact]
@@ -89,9 +89,9 @@ public sealed class GitHubReleaseNotesSettingsExtensionsTest
 
         var actual = original.SetConfigFile("release.yml");
 
-        actual.Should().NotBeSameAs(original);
-        original.ConfigFile.Should().Be(expected: null);
-        actual.ConfigFile.Should().Be("release.yml");
+        actual.ShouldNotBeSameAs(original);
+        original.ConfigFile.ShouldBeNull();
+        actual.ConfigFile.ShouldBe("release.yml");
     }
 
     [Fact]
@@ -102,8 +102,8 @@ public sealed class GitHubReleaseNotesSettingsExtensionsTest
 
         var actual = original.ResetConfigFile();
 
-        actual.Should().NotBeSameAs(original);
-        original.ConfigFile.Should().Be("release.yml");
-        actual.ConfigFile.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.ConfigFile.ShouldBe("release.yml");
+        actual.ConfigFile.ShouldBeNull();
     }
 }

--- a/test/Ayaka.Nuke.Tests/GitHub/GitHubReleaseSettingsExtensionsTest.cs
+++ b/test/Ayaka.Nuke.Tests/GitHub/GitHubReleaseSettingsExtensionsTest.cs
@@ -14,9 +14,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.SetTag("v1.0");
 
-        actual.Should().NotBeSameAs(original);
-        original.Tag.Should().Be(expected: null);
-        actual.Tag.Should().Be("v1.0");
+        actual.ShouldNotBeSameAs(original);
+        original.Tag.ShouldBeNull();
+        actual.Tag.ShouldBe("v1.0");
     }
 
     [Fact]
@@ -27,9 +27,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.ResetTag();
 
-        actual.Should().NotBeSameAs(original);
-        original.Tag.Should().Be("v1.0");
-        actual.Tag.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.Tag.ShouldBe("v1.0");
+        actual.Tag.ShouldBeNull();
     }
 
     [Fact]
@@ -39,9 +39,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.SetTargetCommitish("main");
 
-        actual.Should().NotBeSameAs(original);
-        original.TargetCommitish.Should().Be(expected: null);
-        actual.TargetCommitish.Should().Be("main");
+        actual.ShouldNotBeSameAs(original);
+        original.TargetCommitish.ShouldBeNull();
+        actual.TargetCommitish.ShouldBe("main");
     }
 
     [Fact]
@@ -52,9 +52,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.ResetTargetCommitish();
 
-        actual.Should().NotBeSameAs(original);
-        original.TargetCommitish.Should().Be("main");
-        actual.TargetCommitish.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.TargetCommitish.ShouldBe("main");
+        actual.TargetCommitish.ShouldBeNull();
     }
 
     [Fact]
@@ -64,9 +64,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.SetName("Release v1.0");
 
-        actual.Should().NotBeSameAs(original);
-        original.Name.Should().Be(expected: null);
-        actual.Name.Should().Be("Release v1.0");
+        actual.ShouldNotBeSameAs(original);
+        original.Name.ShouldBeNull();
+        actual.Name.ShouldBe("Release v1.0");
     }
 
     [Fact]
@@ -77,9 +77,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.ResetName();
 
-        actual.Should().NotBeSameAs(original);
-        original.Name.Should().Be("Release v1.0");
-        actual.Name.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.Name.ShouldBe("Release v1.0");
+        actual.Name.ShouldBeNull();
     }
 
     [Fact]
@@ -89,9 +89,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.SetBody("This is the release notes for v1.0.");
 
-        actual.Should().NotBeSameAs(original);
-        original.Body.Should().Be(expected: null);
-        actual.Body.Should().Be("This is the release notes for v1.0.");
+        actual.ShouldNotBeSameAs(original);
+        original.Body.ShouldBeNull();
+        actual.Body.ShouldBe("This is the release notes for v1.0.");
     }
 
     [Fact]
@@ -102,9 +102,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.ResetBody();
 
-        actual.Should().NotBeSameAs(original);
-        original.Body.Should().Be("This is the release notes for v1.0.");
-        actual.Body.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.Body.ShouldBe("This is the release notes for v1.0.");
+        actual.Body.ShouldBeNull();
     }
 
     [Fact]
@@ -114,9 +114,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.SetDraft(draft: true);
 
-        actual.Should().NotBeSameAs(original);
-        original.Draft.Should().Be(expected: null);
-        actual.Draft.Should().Be(expected: true);
+        actual.ShouldNotBeSameAs(original);
+        original.Draft.ShouldBeNull();
+        actual.Draft.ShouldBe(true);
     }
 
     [Fact]
@@ -127,9 +127,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.ResetDraft();
 
-        actual.Should().NotBeSameAs(original);
-        original.Draft.Should().Be(expected: true);
-        actual.Draft.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.Draft.ShouldBe(true);
+        actual.Draft.ShouldBeNull();
     }
 
     [Fact]
@@ -139,9 +139,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.SetPreRelease(preRelease: true);
 
-        actual.Should().NotBeSameAs(original);
-        original.PreRelease.Should().Be(expected: null);
-        actual.PreRelease.Should().Be(expected: true);
+        actual.ShouldNotBeSameAs(original);
+        original.PreRelease.ShouldBeNull();
+        actual.PreRelease.ShouldBe(true);
     }
 
     [Fact]
@@ -152,9 +152,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.ResetPreRelease();
 
-        actual.Should().NotBeSameAs(original);
-        original.PreRelease.Should().Be(expected: true);
-        actual.PreRelease.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.PreRelease.ShouldBe(true);
+        actual.PreRelease.ShouldBeNull();
     }
 
     [Fact]
@@ -164,9 +164,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.SetGenerateReleaseNotes(generateReleaseNotes: true);
 
-        actual.Should().NotBeSameAs(original);
-        original.GenerateReleaseNotes.Should().Be(expected: null);
-        actual.GenerateReleaseNotes.Should().Be(expected: true);
+        actual.ShouldNotBeSameAs(original);
+        original.GenerateReleaseNotes.ShouldBeNull();
+        actual.GenerateReleaseNotes.ShouldBe(true);
     }
 
     [Fact]
@@ -177,9 +177,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.ResetGenerateReleaseNotes();
 
-        actual.Should().NotBeSameAs(original);
-        original.GenerateReleaseNotes.Should().Be(expected: true);
-        actual.GenerateReleaseNotes.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.GenerateReleaseNotes.ShouldBe(true);
+        actual.GenerateReleaseNotes.ShouldBeNull();
     }
 
     [Fact]
@@ -189,9 +189,9 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.AddArtifactPath("path/to/artifact");
 
-        actual.Should().NotBeSameAs(original);
-        original.ArtifactPaths.Should().BeNull();
-        actual.ArtifactPaths.Should().ContainSingle().Which.Should().Be("path/to/artifact");
+        actual.ShouldNotBeSameAs(original);
+        original.ArtifactPaths.ShouldBeNull();
+        actual.ArtifactPaths.ShouldHaveSingleItem().ShouldBe("path/to/artifact");
     }
 
     [Fact]
@@ -202,8 +202,8 @@ public sealed class GitHubReleaseSettingsExtensionsTest
 
         var actual = original.ClearArtifactPaths();
 
-        actual.Should().NotBeSameAs(original);
-        original.ArtifactPaths.Should().ContainSingle().Which.Should().Be("path/to/artifact");
-        actual.ArtifactPaths.Should().BeEmpty();
+        actual.ShouldNotBeSameAs(original);
+        original.ArtifactPaths.ShouldHaveSingleItem().ShouldBe("path/to/artifact");
+        actual.ArtifactPaths.ShouldBeEmpty();
     }
 }

--- a/test/Ayaka.Nuke.Tests/GitHub/GitHubSettingsTest.cs
+++ b/test/Ayaka.Nuke.Tests/GitHub/GitHubSettingsTest.cs
@@ -14,9 +14,9 @@ public sealed class GitHubSettingsExtensionsTest
 
         var actual = original.SetRepositoryOwner("owner");
 
-        actual.Should().NotBeSameAs(original);
-        original.RepositoryOwner.Should().Be(expected: null);
-        actual.RepositoryOwner.Should().Be("owner");
+        actual.ShouldNotBeSameAs(original);
+        original.RepositoryOwner.ShouldBeNull();
+        actual.RepositoryOwner.ShouldBe("owner");
     }
 
     [Fact]
@@ -27,9 +27,9 @@ public sealed class GitHubSettingsExtensionsTest
 
         var actual = original.ResetRepositoryOwner();
 
-        actual.Should().NotBeSameAs(original);
-        original.RepositoryOwner.Should().Be("owner");
-        actual.RepositoryOwner.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.RepositoryOwner.ShouldBe("owner");
+        actual.RepositoryOwner.ShouldBeNull();
     }
 
     [Fact]
@@ -39,9 +39,9 @@ public sealed class GitHubSettingsExtensionsTest
 
         var actual = original.SetRepositoryName("name");
 
-        actual.Should().NotBeSameAs(original);
-        original.RepositoryName.Should().Be(expected: null);
-        actual.RepositoryName.Should().Be("name");
+        actual.ShouldNotBeSameAs(original);
+        original.RepositoryName.ShouldBeNull();
+        actual.RepositoryName.ShouldBe("name");
     }
 
     [Fact]
@@ -52,9 +52,9 @@ public sealed class GitHubSettingsExtensionsTest
 
         var actual = original.ResetRepositoryName();
 
-        actual.Should().NotBeSameAs(original);
-        original.RepositoryName.Should().Be("name");
-        actual.RepositoryName.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.RepositoryName.ShouldBe("name");
+        actual.RepositoryName.ShouldBeNull();
     }
 
     [Fact]
@@ -64,9 +64,9 @@ public sealed class GitHubSettingsExtensionsTest
 
         var actual = original.SetToken("token");
 
-        actual.Should().NotBeSameAs(original);
-        original.Token.Should().Be(expected: null);
-        actual.Token.Should().Be("token");
+        actual.ShouldNotBeSameAs(original);
+        original.Token.ShouldBeNull();
+        actual.Token.ShouldBe("token");
     }
 
     [Fact]
@@ -77,9 +77,9 @@ public sealed class GitHubSettingsExtensionsTest
 
         var actual = original.ResetToken();
 
-        actual.Should().NotBeSameAs(original);
-        original.Token.Should().Be("token");
-        actual.Token.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.Token.ShouldBe("token");
+        actual.Token.ShouldBeNull();
     }
 
     [Fact]
@@ -89,9 +89,9 @@ public sealed class GitHubSettingsExtensionsTest
 
         var actual = original.SetBaseUrl("url");
 
-        actual.Should().NotBeSameAs(original);
-        original.BaseUrl.Should().Be(expected: null);
-        actual.BaseUrl.Should().Be("url");
+        actual.ShouldNotBeSameAs(original);
+        original.BaseUrl.ShouldBeNull();
+        actual.BaseUrl.ShouldBe("url");
     }
 
     [Fact]
@@ -102,8 +102,8 @@ public sealed class GitHubSettingsExtensionsTest
 
         var actual = original.ResetBaseUrl();
 
-        actual.Should().NotBeSameAs(original);
-        original.BaseUrl.Should().Be("url");
-        actual.BaseUrl.Should().Be(expected: null);
+        actual.ShouldNotBeSameAs(original);
+        original.BaseUrl.ShouldBe("url");
+        actual.BaseUrl.ShouldBeNull();
     }
 }

--- a/test/Ayaka.Nuke.Tests/PublicApi/IgnoreCaseWhenPossibleComparer.cs
+++ b/test/Ayaka.Nuke.Tests/PublicApi/IgnoreCaseWhenPossibleComparer.cs
@@ -22,8 +22,7 @@ public sealed class IgnoreCaseWhenPossibleComparerTest
         lines.Sort(IgnoreCaseWhenPossibleComparer.Instance);
 
         lines
-            .Should()
-            .BeEquivalentTo(
+            .ShouldBe(
                 [
                     "#nullable enable",
                     "Ayaka.Nuke.DotNet.ICanDotNetBuild",
@@ -31,8 +30,7 @@ public sealed class IgnoreCaseWhenPossibleComparerTest
                     "Ayaka.Nuke.DotNet.ICanDotNetBuild.DotNetBuildSettingsBase.get -> Nuke.Common.Tooling.Configure<Nuke.Common.Tools.DotNet.DotNetBuildSettings!>!",
                     "Ayaka.Nuke.DotNet.IHaveDotNetPackTarget",
                     "Ayaka.Nuke.Extensions"
-                ],
-                o => o.WithStrictOrdering());
+                ]);
     }
 
     [Fact]
@@ -48,13 +46,11 @@ public sealed class IgnoreCaseWhenPossibleComparerTest
         lines.Sort(IgnoreCaseWhenPossibleComparer.Instance);
 
         lines
-            .Should()
-            .BeEquivalentTo(
+            .ShouldBe(
                 [
                     "Ayaka.Nuke.DotNet.ICanDotNetBuild",
                     "Ayaka.Nuke.Extensions",
                     "ayaka.nuke.extensions",
-                ],
-                o => o.WithStrictOrdering());
+                ]);
     }
 }


### PR DESCRIPTION
## Description

FluentAssertions v8+ moved to a commercial license, leaving v7 frozen. Swap the assertion library to Shouldly 4.3.0 (MIT) across all test projects:

- eng/: swap the package reference and global using, drop FluentAssertions.Analyzers (Shouldly ships no analyzer)
- rewrite all ~250 assertion sites in 21 test files
- exception assertions use the static Should.Throw* form with a chained .Message.ShouldBe(...)
- deep structural equivalence via ShouldBeEquivalentTo where record equality would compare members by reference (TenantStoreCompliance, DefaultTenantManagerTest)
- chain on the values returned by ShouldHaveSingleItem() and ShouldBeOfType<T>() instead of re-indexing or casting
- drop null-forgiving operators obsoleted by Shouldly's [NotNull] postcondition on ShouldNotBeNull()
- update agent docs (AGENTS.md, .claude/rules/, Copilot mirror)

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Unit Tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
